### PR TITLE
fix: remove string translation on eventIDs to fix rule matching errors

### DIFF
--- a/src/hunt/modules.rs
+++ b/src/hunt/modules.rs
@@ -212,7 +212,7 @@ pub fn detect_tau_matches(
                 };
                 doc[k] = json!(h);
             }
-            doc["EventID"] = json!(event_id.to_string());
+            doc["EventID"] = json!(event_id);
 
             // Find the context_field and extract it's value from the event
             command_line = match fields.table_headers.get("context_field") {


### PR DESCRIPTION
Closes #19 