### PR TITLE
Add SHA1 Support to Sophos Rule and Add System Provider

### DIFF
--- a/rules/antivirus/sophos.yml
+++ b/rules/antivirus/sophos.yml
@@ -25,7 +25,13 @@ fields:
     to: Event.EventData.Data[2]
   - name: Threat Path
     to: Event.EventData.Data[1]
-
+  - name: SHA1
+    container:
+      field: Event.EventData.Data[4]
+      format: json
+    to: sha1FileHash  
 
 filter:
-  Event.System.Provider: Sophos Anti-Virus
+  Event.System.Provider:
+    - Sophos Anti-Virus
+    - Sophos System Protection


### PR DESCRIPTION
Thanks for fixing issue #132! I tested it there and everything works as expected. With this PR I added SHA1 Support based on the Events I have seen from Sophos System Protection and added it as a Provider