### PR TITLE
Add rules for Microsoft Remote Access VPN (client and server)

### DIFF
--- a/rules/microsoft_rasvpn_events/eid_20220_20227_rasvpn_client_connection_error.yml
+++ b/rules/microsoft_rasvpn_events/eid_20220_20227_rasvpn_client_connection_error.yml
@@ -1,0 +1,38 @@
+---
+title: Microsoft Remote Access VPN - Client - Connection error
+group: Microsoft Remote Access VPN
+description: Microsoft Remote Access VPN - Client - Connection error. EID 20220 or 20227.
+authors: 
+  - Théo Letailleur
+  - Synacktiv
+
+kind: evtx
+level: low
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Channel
+    to: Event.System.Channel
+  - name: Provider
+    to: Event.System.Provider
+  - name: Computer
+    to: Event.System.Computer
+  - name: Data
+    to: Event.EventData.Data
+
+filter:
+  condition: invalid_server_cert or rasconnection_failed
+
+  invalid_server_cert:
+      Event.System.EventID: 20227
+      Event.System.Channel: Application
+      Event.System.Provider: RasClient
+
+  rasconnection_failed:
+      Event.System.EventID: 20227
+      Event.System.Channel: Application
+      Event.System.Provider: RasClient

--- a/rules/microsoft_rasvpn_events/eid_20221_to_20225_rasvpn_client_connection_establishment.yml
+++ b/rules/microsoft_rasvpn_events/eid_20221_to_20225_rasvpn_client_connection_establishment.yml
@@ -1,0 +1,49 @@
+---
+title: Microsoft Remote Access VPN - Client - Connection establishment
+group: Microsoft Remote Access VPN
+description: Microsoft Remote Access VPN - Client - Connection establishment. Suite of EIDs 20221->20222->20223->20224->20224
+authors: 
+  - Théo Letailleur
+  - Synacktiv
+
+kind: evtx
+level: info
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Channel
+    to: Event.System.Channel
+  - name: Provider
+    to: Event.System.Provider
+  - name: Computer
+    to: Event.System.Computer
+  - name: Data
+    to: Event.EventData.Data
+
+filter:
+  condition: preconnect_info or connecting_device or device_connected or link_established or rasconnection_established
+
+  preconnect_info:
+      Event.System.EventID: 20221
+      Event.System.Channel: Application
+      Event.System.Provider: RasClient
+  connecting_device:
+      Event.System.EventID: 20222
+      Event.System.Channel: Application
+      Event.System.Provider: RasClient
+  device_connected:
+      Event.System.EventID: 20223
+      Event.System.Channel: Application
+      Event.System.Provider: RasClient
+  link_established:
+      Event.System.EventID: 20224
+      Event.System.Channel: Application
+      Event.System.Provider: RasClient
+  rasconnection_established:
+      Event.System.EventID: 20225
+      Event.System.Channel: Application
+      Event.System.Provider: RasClient

--- a/rules/microsoft_rasvpn_events/eid_20226_rasvpn_client_connection_termination.yml
+++ b/rules/microsoft_rasvpn_events/eid_20226_rasvpn_client_connection_termination.yml
@@ -1,0 +1,33 @@
+---
+title: Microsoft Remote Access VPN - Client - Connection termination
+group: Microsoft Remote Access VPN
+description: Microsoft Remote Access VPN - Client - Connection termination. EID 20226
+authors: 
+  - Théo Letailleur
+  - Synacktiv
+
+kind: evtx
+level: info
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Channel
+    to: Event.System.Channel
+  - name: Provider
+    to: Event.System.Provider
+  - name: Computer
+    to: Event.System.Computer
+  - name: Data
+    to: Event.EventData.Data
+
+filter:
+  condition: rasconnection_terminated
+
+  rasconnection_terminated:
+      Event.System.EventID: 20226
+      Event.System.Channel: Application
+      Event.System.Provider: RasClient

--- a/rules/microsoft_rasvpn_events/eid_20250_20274_rasvpn_server_logon.yml
+++ b/rules/microsoft_rasvpn_events/eid_20250_20274_rasvpn_server_logon.yml
@@ -1,0 +1,37 @@
+---
+title: Microsoft Remote Access VPN - Server - User logon
+group: Microsoft Remote Access VPN
+description: Microsoft Remote Access VPN - Server - User logon successful EID 20250 followed by EID 20274
+authors: 
+  - Théo Letailleur
+  - Synacktiv
+
+kind: evtx
+level: info
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Channel
+    to: Event.System.Channel
+  - name: Provider
+    to: Event.System.Provider
+  - name: Computer
+    to: Event.System.Computer
+  - name: Data
+    to: Event.EventData.Data
+
+filter:
+  condition: auth_success or ip_user_connected
+
+  auth_success:
+      Event.System.EventID: 20250
+      Event.System.Channel: System
+      Event.System.Provider: RemoteAccess
+  ip_user_connected:
+      Event.System.EventID: 20274
+      Event.System.Channel: System
+      Event.System.Provider: RemoteAccess

--- a/rules/microsoft_rasvpn_events/eid_20253_20255_connection_error.yml
+++ b/rules/microsoft_rasvpn_events/eid_20253_20255_connection_error.yml
@@ -1,0 +1,37 @@
+---
+title: Microsoft Remote Access VPN - Server - Connection error
+group: Microsoft Remote Access VPN
+description: Microsoft Remote Access VPN - Server - Connection error EID 20253 or EID 20255
+authors: 
+  - Théo Letailleur
+  - Synacktiv
+
+kind: evtx
+level: low
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Channel
+    to: Event.System.Channel
+  - name: Provider
+    to: Event.System.Provider
+  - name: Computer
+    to: Event.System.Computer
+  - name: Data
+    to: Event.EventData.Data
+
+filter:
+  condition: auth_no_projections or ppp_failure
+
+  auth_no_projections:
+      Event.System.EventID: 20253
+      Event.System.Channel: System
+      Event.System.Provider: RemoteAccess
+  ppp_failure:
+      Event.System.EventID: 20255
+      Event.System.Channel: System
+      Event.System.Provider: RemoteAccess

--- a/rules/microsoft_rasvpn_events/eid_20271_rasvpn_server_authentication_error.yml
+++ b/rules/microsoft_rasvpn_events/eid_20271_rasvpn_server_authentication_error.yml
@@ -1,0 +1,33 @@
+---
+title: Microsoft Remote Access VPN - Server - Authentication error
+group: Microsoft Remote Access VPN
+description: Microsoft Remote Access VPN - Server - Authentication error EID 20271
+authors: 
+  - Théo Letailleur
+  - Synacktiv
+
+kind: evtx
+level: low
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Channel
+    to: Event.System.Channel
+  - name: Provider
+    to: Event.System.Provider
+  - name: Computer
+    to: Event.System.Computer
+  - name: Data
+    to: Event.EventData.Data
+
+filter:
+  condition: ntauth_failure
+
+  ntauth_failure:
+      Event.System.EventID: 20271
+      Event.System.Channel: System
+      Event.System.Provider: RemoteAccess

--- a/rules/microsoft_rasvpn_events/eid_20272_20275_rasvpn_server_logoff.yml
+++ b/rules/microsoft_rasvpn_events/eid_20272_20275_rasvpn_server_logoff.yml
@@ -1,0 +1,37 @@
+---
+title: Microsoft Remote Access VPN - Server - User logoff
+group: Microsoft Remote Access VPN
+description: Microsoft Remote Access VPN - Server - User logoff EID 20272 usually followed by EID 20275
+authors: 
+  - Théo Letailleur
+  - Synacktiv
+
+kind: evtx
+level: info
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Channel
+    to: Event.System.Channel
+  - name: Provider
+    to: Event.System.Provider
+  - name: Computer
+    to: Event.System.Computer
+  - name: Data
+    to: Event.EventData.Data
+
+filter:
+  condition: user_active_time_vpn or ip_user_disconnected
+
+  user_active_time_vpn:
+      Event.System.EventID: 20272
+      Event.System.Channel: System
+      Event.System.Provider: RemoteAccess
+  ip_user_disconnected:
+      Event.System.EventID: 20275
+      Event.System.Channel: System
+      Event.System.Provider: RemoteAccess


### PR DESCRIPTION
This PR adds 7 rules to detect connection activity on Microsoft Remote Access VPN on both client and server sides.

Reference: https://github.com/synacktiv/forensic-msvpn
