### PR TITLE
Update Windows Defender rule to filter for key EventIDs

### DIFF
--- a/rules/antivirus/windows_defender.yml
+++ b/rules/antivirus/windows_defender.yml
@@ -29,3 +29,18 @@ fields:
 
 filter:
   Event.System.Provider: Microsoft-Windows-Windows Defender
+  Event.System.EventID:
+  # From https://learn.microsoft.com/en-us/microsoft-365/security/defender-endpoint/troubleshoot-microsoft-defender-antivirus
+  - 1006 # The antimalware engine found malware or other potentially unwanted software.
+  - 1007 # The antimalware platform performed an action to protect your system from malware or other potentially unwanted software.
+  - 1008 # The antimalware platform attempted to perform an action to protect your system from malware or other potentially unwanted software, but the action failed.
+  - 1009 # The antimalware platform restored an item from quarantine.
+  - 1010 # The antimalware platform couldn't restore an item from quarantine.
+  - 1011 # The antimalware platform deleted an item from quarantine.
+  - 1012 # The antimalware platform couldn't delete an item from quarantine.
+  - 1015 # The antimalware platform detected suspicious behavior.
+  - 1116 # The antimalware platform detected malware or other potentially unwanted software.
+  - 1117 # The antimalware platform performed an action to protect your system from malware or other potentially unwanted software.
+  - 1118 # The antimalware platform attempted to perform an action to protect your system from malware or other potentially unwanted software, but the action failed.
+  - 1119 # The antimalware platform encountered a critical error when trying to take action on malware or other potentially unwanted software. There are more details in the event message.
+  - 1127 # Controlled Folder Access(CFA) blocked an untrusted process from making changes to the memory.


### PR DESCRIPTION
This updates the windows_defender.yml rule file to filter for EventIDs instead of saving all of the EventIDs to the spreadsheet. This should cut down on the noise of the resulting antivirus file. Tested on several engagements and works well.