### PR TITLE
Update Sigma Mapping File to Reduce False Positives

### DIFF
--- a/mappings/sigma-event-logs-all.yml
+++ b/mappings/sigma-event-logs-all.yml
@@ -24,13 +24,130 @@ exclusions:
 extensions:
   preconditions:
     - for:
-        logsource.service: windefend
+        logsource.category: process_creation
       filter:
-        Provider: Microsoft-Windows-Windows Defender
+        - Provider: Microsoft-Windows-Sysmon
+        - Provider: Microsoft-Windows-Security-Auditing
+    - for:
+        logsource.category: network_connection
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 3
+    - for:
+        logsource.category: sysmon_status
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+    - for:
+        logsource.category: driver_load
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 6
+    - for:
+        logsource.category: image_load
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 7
+    - for:
+        logsource.category: create_remote_thread
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 8
+    - for:
+        logsource.category: raw_access_thread
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 9
+    - for:
+        logsource.category: process_access
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 10
+    - for:
+        logsource.category: file_event
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 11
+    - for:
+        logsource.category: registry_event
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+    - for:
+        logsource.category: registry_add
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 12
+    - for:
+        logsource.category: registry_delete
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 12
+    - for:
+        logsource.category: registry_set
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 13
+    - for:
+        logsource.category: create_stream_hash
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 15
+    - for:
+        logsource.category: pipe_created
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+    - for:
+        logsource.category: wmi_event
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+    - for:
+        logsource.category: dns_query
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 22
+    - for:
+        logsource.category: file_delete
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 23
+    - for:
+        logsource.category: process_tampering
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 25
+    - for:
+        logsource.category: file_delete_detected
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 26
     - for:
         logsource.category: file_block
       filter:
         Provider: Microsoft-Windows-Sysmon
+        int(EventID): 27
+    - for:
+        logsource.category: file_block_executable
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 27
+    - for:
+        logsource.category: file_block_shredding
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 28
+    - for:
+        logsource.category: file_executable_detected
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 29
+    - for:
+        logsource.category: sysmon_error
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 255
+    - for:
+        logsource.service: windefend
+      filter:
+        Provider: Microsoft-Windows-Windows Defender
     - for:
         logsource.service: sysmon
       filter:
@@ -143,6 +260,22 @@ extensions:
         logsource.service: lsa-server
       filter:
         Provider: LsaSrv
+    - for:
+        logsource.service: kernel-shimengine
+      filter:
+        Provider: Microsoft-Windows-Kernel-ShimEngine
+    - for:
+        logsource.service: application-experience
+      filter:
+        Provider: Microsoft-Windows-Application-Experience
+    - for:
+        logsource.service: ntfs
+      filter:
+        Provider: Microsoft-Windows-Ntfs
+    - for:
+        logsource.service: hyper-v-worker
+      filter:
+        Provider: Microsoft-Windows-Hyper-V-Worker
     - for:
         id: 4a3a2b96-d7fc-4cb9-80e4-4a545fe95f46 #Remote Service Creation Rule
       filter:

--- a/mappings/sigma-event-logs-all.yml
+++ b/mappings/sigma-event-logs-all.yml
@@ -241,6 +241,10 @@ extensions:
       filter:
         Provider: OpenSSH
     - for:
+        logsource.service: ldap
+      filter:
+        Provider: Microsoft-Windows-LDAP-Client
+    - for:
         logsource.service: ldap_debug
       filter:
         Provider: Microsoft-Windows-LDAP-Client
@@ -276,6 +280,14 @@ extensions:
         logsource.service: hyper-v-worker
       filter:
         Provider: Microsoft-Windows-Hyper-V-Worker
+    - for:
+        logsource.service: driver-framework
+      filter:
+        Provider: Microsoft-Windows-DriverFrameworks-UserMode
+    - for:
+        logsource.service: msexchange-management
+      filter:
+        Provider: MSExchange CmdletLogs
     - for:
         id: 4a3a2b96-d7fc-4cb9-80e4-4a545fe95f46 #Remote Service Creation Rule
       filter:

--- a/mappings/sigma-event-logs-all.yml
+++ b/mappings/sigma-event-logs-all.yml
@@ -27,7 +27,9 @@ extensions:
         logsource.category: process_creation
       filter:
         - Provider: Microsoft-Windows-Sysmon
+          int(EventID): 1
         - Provider: Microsoft-Windows-Security-Auditing
+          int(EventID): 4688
     - for:
         logsource.category: network_connection
       filter:
@@ -37,6 +39,14 @@ extensions:
         logsource.category: sysmon_status
       filter:
         Provider: Microsoft-Windows-Sysmon
+        int(EventID):
+        - 4
+        - 16
+    - for:
+        logsource.category: process_termination
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 5
     - for:
         logsource.category: driver_load
       filter:
@@ -71,6 +81,10 @@ extensions:
         logsource.category: registry_event
       filter:
         Provider: Microsoft-Windows-Sysmon
+        int(EventID):
+        - 12
+        - 13
+        - 14
     - for:
         logsource.category: registry_add
       filter:
@@ -87,6 +101,11 @@ extensions:
         Provider: Microsoft-Windows-Sysmon
         int(EventID): 13
     - for:
+        logsource.category: registry_rename
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 14
+    - for:
         logsource.category: create_stream_hash
       filter:
         Provider: Microsoft-Windows-Sysmon
@@ -95,10 +114,17 @@ extensions:
         logsource.category: pipe_created
       filter:
         Provider: Microsoft-Windows-Sysmon
+        int(EventID):
+        - 17
+        - 18
     - for:
         logsource.category: wmi_event
       filter:
         Provider: Microsoft-Windows-Sysmon
+        int(EventID):
+        - 19
+        - 20
+        - 21
     - for:
         logsource.category: dns_query
       filter:
@@ -109,6 +135,11 @@ extensions:
       filter:
         Provider: Microsoft-Windows-Sysmon
         int(EventID): 23
+    - for:
+        logsource.category: clipboard_change
+      filter:
+        Provider: Microsoft-Windows-Sysmon
+        int(EventID): 24
     - for:
         logsource.category: process_tampering
       filter:


### PR DESCRIPTION
This is a continuation of Pull Request #130 and reduces the false positive rate of sigma rules. Using [these](https://github.com/Yamato-Security/hayabusa-sample-evtx) event logs as a test I managed to reduce the sigma.csv from 5083KB to 4781KB a decrease of around 5.94%. 

Unfortunately I could not figure out how to use multiple EventID filters for some of these so there is most likely still some improvement that could be made here.

I tried both of these with the top one not erroring but continuing to show 4688 events for process_creation instead of taking them off due to me wanting to just have EventIDs 1 and 999 for testing. The second one errored claiming it was duplicated. 

This does not necessarily hold this pull request up as I can always create a new one after this is merged if you can tell me where I am going wrong (Probably something simple).
```
- for:
        logsource.category: process_creation
      filter:
        - Provider: Microsoft-Windows-Sysmon
        - Provider: Microsoft-Windows-Security-Auditing
        - int(EventID): 1
        - int(EventID): 999

- for:
        logsource.category: process_creation
      filter:
        int(EventID): 1
        int(EventID): 999 
        - Provider: Microsoft-Windows-Sysmon
        - Provider: Microsoft-Windows-Security-Auditing
```