### PR TITLE
Service Installation 7045 Rules

### DIFF
--- a/rules/service_installation/credential_dumping_tools.yml
+++ b/rules/service_installation/credential_dumping_tools.yml
@@ -1,0 +1,58 @@
+---
+title: Credential Dumping Tools Service Installation
+group: Service Installation 
+description: A Credential Dumping Tool Service Was Installed - https://www.slideshare.net/heirhabarov/hunting-for-credentials-dumping-in-windows-environment
+authors:
+  - reece394
+
+
+kind: evtx
+level: critical
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Record ID
+    to: Event.System.EventRecordID
+  - name: Computer
+    to: Event.System.Computer
+  - name: Service Name
+    to: Event.EventData.ServiceName
+  - name: Service File Name
+    to: Event.EventData.ImagePath
+  - name: Service Type
+    to: Event.EventData.ServiceType
+  - name: Service Start Type
+    to: Event.EventData.StartType  
+  - name: Service Account
+    to: Event.EventData.AccountName  
+
+filter:
+  condition: service_control_manager and (service_name or image_path)
+
+  service_control_manager:
+    Event.System.Provider: Service Control Manager
+    Event.System.EventID: 7045
+
+  service_name:
+    Event.EventData.ServiceName:
+      - 'i*fgexec*'
+      - 'i*CacheDump*'
+      - 'i*mimikatz*'
+      - 'i*mimidrv*'
+      - 'i*mimikatzsvc*'
+      - 'i*WCESERVICE*'
+      - 'i*PWDump*'
+
+  image_path:
+    Event.EventData.ImagePath:
+      - 'i*cachedump*'
+      - 'i*dumpsvc*'
+      - 'i*fgexec*'
+      - 'i*gsecdump*'
+      - 'i*mimidrv*'
+      - 'i*pwdump*'
+      - 'i*servpw*'

--- a/rules/service_installation/csexec.yml
+++ b/rules/service_installation/csexec.yml
@@ -1,0 +1,46 @@
+---
+title: CSExec Service Installation
+group: Service Installation 
+description: A CSExec Service Was Installed - https://github.com/malcomvetter/CSExec
+authors:
+  - reece394
+
+
+kind: evtx
+level: medium
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Record ID
+    to: Event.System.EventRecordID
+  - name: Computer
+    to: Event.System.Computer
+  - name: Service Name
+    to: Event.EventData.ServiceName
+  - name: Service File Name
+    to: Event.EventData.ImagePath
+  - name: Service Type
+    to: Event.EventData.ServiceType
+  - name: Service Start Type
+    to: Event.EventData.StartType  
+  - name: Service Account
+    to: Event.EventData.AccountName  
+
+filter:
+  condition: service_control_manager and (service_name or image_path)
+
+  service_control_manager:
+    Event.System.Provider: Service Control Manager
+    Event.System.EventID: 7045
+
+  service_name:
+    Event.EventData.ServiceName:
+      - 'i*csexecsvc*'
+
+  image_path:
+    Event.EventData.ImagePath:
+      - 'i*csexecsvc.exe*'

--- a/rules/service_installation/krbrelayup.yml
+++ b/rules/service_installation/krbrelayup.yml
@@ -1,0 +1,42 @@
+---
+title: KrbRelayUp Service Installation
+group: Service Installation 
+description: A KrbRelayUp Service Was Installed - a universal no-fix local privilege escalation in windows domain environments where LDAP signing is not enforced (the default settings).
+authors:
+  - reece394
+
+
+kind: evtx
+level: critical
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Record ID
+    to: Event.System.EventRecordID
+  - name: Computer
+    to: Event.System.Computer
+  - name: Service Name
+    to: Event.EventData.ServiceName
+  - name: Service File Name
+    to: Event.EventData.ImagePath
+  - name: Service Type
+    to: Event.EventData.ServiceType
+  - name: Service Start Type
+    to: Event.EventData.StartType  
+  - name: Service Account
+    to: Event.EventData.AccountName  
+
+filter:
+  condition: service_control_manager and service_name
+
+  service_control_manager:
+    Event.System.Provider: Service Control Manager
+    Event.System.EventID: 7045
+
+  service_name:
+    Event.EventData.ServiceName:
+      - 'i*KrbSCM*'

--- a/rules/service_installation/meterpreter_cobalt_strike_getsystem.yml
+++ b/rules/service_installation/meterpreter_cobalt_strike_getsystem.yml
@@ -1,0 +1,57 @@
+---
+title: Meterpreter or Cobalt Strike Getsystem Service Installation
+group: Service Installation 
+description: A Meterpreter or Cobalt Strike Getsystem Service Was Installed - https://speakerdeck.com/heirhabarov/hunting-for-privilege-escalation-in-windows-environment 
+authors:
+  - reece394
+
+
+kind: evtx
+level: critical
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Record ID
+    to: Event.System.EventRecordID
+  - name: Computer
+    to: Event.System.Computer
+  - name: Service Name
+    to: Event.EventData.ServiceName
+  - name: Service File Name
+    to: Event.EventData.ImagePath
+  - name: Service Type
+    to: Event.EventData.ServiceType
+  - name: Service Start Type
+    to: Event.EventData.StartType  
+  - name: Service Account
+    to: Event.EventData.AccountName  
+
+filter:
+  condition: service_control_manager and (cmd or rundll or share)
+
+  service_control_manager:
+    Event.System.Provider: Service Control Manager
+    Event.System.EventID: 7045
+
+  cmd:
+    all(Event.EventData.ImagePath):
+      - 'i*/c*'
+      - 'i*echo*'
+      - 'i*\pipe*'
+    Event.EventData.ImagePath:
+        - 'i*cmd*'
+        - 'i*%COMSPEC%*'
+
+  rundll:
+    all(Event.EventData.ImagePath):
+      - 'i*rundll32*'
+      - 'i*.dll,a*'
+      - 'i*/p:*'
+
+  share:
+    Event.EventData.ImagePath:
+      - 'i\\\\127.0.0.1\\ADMIN$\*'  

--- a/rules/service_installation/powershell.yml
+++ b/rules/service_installation/powershell.yml
@@ -1,0 +1,44 @@
+---
+title: PowerShell Script Service Installation
+group: Service Installation 
+description: A PowerShell Script as a Service Was Installed
+authors:
+  - reece394
+
+
+kind: evtx
+level: critical
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Record ID
+    to: Event.System.EventRecordID
+  - name: Computer
+    to: Event.System.Computer
+  - name: Service Name
+    to: Event.EventData.ServiceName
+  - name: Service File Name
+    to: Event.EventData.ImagePath
+  - name: Service Type
+    to: Event.EventData.ServiceType
+  - name: Service Start Type
+    to: Event.EventData.StartType  
+  - name: Service Account
+    to: Event.EventData.AccountName  
+
+filter:
+  condition: service_control_manager and service_name
+
+  service_control_manager:
+    Event.System.Provider: Service Control Manager
+    Event.System.EventID: 7045
+
+  service_name:
+    Event.EventData.ImagePath:
+      - 'i*powershell*'
+      - 'i*pwsh*'
+      - 'i*-encodedcommand*'

--- a/rules/service_installation/processhacker.yml
+++ b/rules/service_installation/processhacker.yml
@@ -1,0 +1,42 @@
+---
+title: ProcessHacker Service Installation
+group: Service Installation 
+description: A ProcessHacker Service Was Installed - Can Be Used to Elevate Privileges
+authors:
+  - reece394
+
+
+kind: evtx
+level: critical
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Record ID
+    to: Event.System.EventRecordID
+  - name: Computer
+    to: Event.System.Computer
+  - name: Service Name
+    to: Event.EventData.ServiceName
+  - name: Service File Name
+    to: Event.EventData.ImagePath
+  - name: Service Type
+    to: Event.EventData.ServiceType
+  - name: Service Start Type
+    to: Event.EventData.StartType  
+  - name: Service Account
+    to: Event.EventData.AccountName  
+
+filter:
+  condition: service_control_manager and service_name
+
+  service_control_manager:
+    Event.System.Provider: Service Control Manager
+    Event.System.EventID: 7045
+
+  service_name:
+    Event.EventData.ServiceName:
+      - 'i*ProcessHacker*'

--- a/rules/service_installation/remote_access_tools.yml
+++ b/rules/service_installation/remote_access_tools.yml
@@ -1,0 +1,117 @@
+---
+title: Remote Access Tool Service Installation
+group: Service Installation 
+description: A Remote Access Tool Service Was Installed
+authors:
+  - reece394
+
+
+kind: evtx
+level: medium
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Record ID
+    to: Event.System.EventRecordID
+  - name: Computer
+    to: Event.System.Computer
+  - name: Service Name
+    to: Event.EventData.ServiceName
+  - name: Service File Name
+    to: Event.EventData.ImagePath
+  - name: Service Type
+    to: Event.EventData.ServiceType
+  - name: Service Start Type
+    to: Event.EventData.StartType  
+  - name: Service Account
+    to: Event.EventData.AccountName  
+
+filter:
+  condition: service_control_manager and (service_name or image_path)
+
+  service_control_manager:
+    Event.System.Provider: Service Control Manager
+    Event.System.EventID: 7045
+
+  service_name:
+    Event.EventData.ServiceName:
+      - 'i*AnyDesk*'
+      - 'i*Ammyy*'
+      - 'i*Atera*'
+      - 'i*GoTo Resolve*'
+      - 'i*GoToMyPC*'
+      - 'i*LMIGuardianSvc*'
+      - 'i*LogMeIn*'
+      - 'i*GoToAssist*'
+      - 'i*Parsec*'
+      - 'i*Remote Utilities - Host*'
+      - 'i*VPDAgent*' # Installed by Remote Utilities
+      - 'i*Client32*' # Installed by NetSupport Manager
+      - 'i*nskbfltr*' # Installed by NetSupport Manager
+      - 'i*Gateway32*' # Installed by NetSupport Manager if Connectivity Server is Selected During Install
+      - 'i*MeshCentral*'
+      - 'i*Mesh Agent*'
+      - 'i*RPCService*' # Installed by RemotePC
+      - 'i*ViewerService*' # Installed by RemotePC
+      - 'i*RemotePC Performance Service*' # Installed by RemotePC
+      - 'i*Splashtop*'
+      - 'i*TeamViewer*'
+      - 'i*TightVNC*'
+      - 'i*RealVNC*'
+      - 'i*Zoho Assist*'
+      - 'i*pcAnywhere*'
+      - 'i*UltraViewer*'
+      - 'i*Supremo*'
+      - 'i*ScreenConnect*'
+      - 'i*Chrome Remote Desktop*'
+      - 'i*N-central Take Control Service*'
+      - 'i*N-central Take Control Updater Service*'
+      - 'i*monblanking*'
+      - 'i*jumpcloud*'
+
+  image_path:
+    Event.EventData.ImagePath:
+      - 'i*AnyDesk.exe*'
+      - 'i*AA_v3.exe*'
+      - 'i*g2r-updater.exe*'
+      - 'i*g2svc.exe*'
+      - 'i*LMIGuardianSvc.exe*'
+      - 'i*ramaint.exe*'
+      - 'i*LogMeIn.exe*'
+      - 'i*RaMaint.exe*'
+      - 'i*LMIInfo.sys*'
+      - 'i*LMIRfsDriver.sys*'
+      - 'i*g2ax_service.exe*'
+      - 'i*pservice.exe*'
+      - 'i*rutserv.exe*'
+      - 'i*VPDAgent.exe*'
+      - 'i*client32.exe*'
+      - 'i*nskbfltr.sys*'
+      - 'i*Gateway32.exe*'
+      - 'i*meshcentral.exe*'
+      - 'i*MeshAgent.exe*'
+      - 'i*RemotePCService.exe*'
+      - 'i*ViewerService.exe*'
+      - 'i*RPCPerformanceService.exe*'
+      - 'i*SSUService.exe*'
+      - 'i*SRService.exe*'
+      - 'i*TeamViewer_Service.exe*'
+      - 'i*tvnserver.exe*'
+      - 'i*vncserver.exe*'
+      - 'i*ZohoURSService.exe*'
+      - 'i*awhost32.exe*'
+      - 'i*UltraViewer_Service.exe*'
+      - 'i*SupremoSystem.exe*'
+      - 'i*SupremoService.exe*'
+      - 'i*ScreenConnect.ClientService.exe*'
+      - 'i*remoting_host.exe*'
+      - 'i*AteraAgent.exe*'
+      - 'i*OpenHardwareMonitorLib.sys*'
+      - 'i*BASupSrvc.exe*'
+      - 'i*BASupSrvcUpdater.exe*'
+      - 'i*monblanking.sys*'
+      - 'i*jumpcloud-agent.exe*'

--- a/rules/service_installation/smbexec.yml
+++ b/rules/service_installation/smbexec.yml
@@ -1,0 +1,47 @@
+---
+title: Impacket smbexec.py Service Installation
+group: Service Installation 
+description: An Impacket smbexec Service Was Installed
+authors:
+  - reece394
+
+
+kind: evtx
+level: critical
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Record ID
+    to: Event.System.EventRecordID
+  - name: Computer
+    to: Event.System.Computer
+  - name: Service Name
+    to: Event.EventData.ServiceName
+  - name: Service File Name
+    to: Event.EventData.ImagePath
+  - name: Service Type
+    to: Event.EventData.ServiceType
+  - name: Service Start Type
+    to: Event.EventData.StartType  
+  - name: Service Account
+    to: Event.EventData.AccountName  
+
+filter:
+  condition: service_control_manager and (service_name or image_path)
+
+  service_control_manager:
+    Event.System.Provider: Service Control Manager
+    Event.System.EventID: 7045
+
+  service_name:
+    Event.EventData.ServiceName:
+      - 'i*BTOBTO*'
+
+  image_path:
+    Event.EventData.ImagePath:
+      - 'i*.bat & del *'
+      - 'i*__output 2^>^&1 >*'

--- a/rules/service_installation/suspicious_commands.yml
+++ b/rules/service_installation/suspicious_commands.yml
@@ -1,0 +1,46 @@
+---
+title: Suspicious Commands Service Installation
+group: Service Installation 
+description: Suspicious Commands were found in a Service that Was Installed
+authors:
+  - reece394
+
+
+kind: evtx
+level: medium
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Record ID
+    to: Event.System.EventRecordID
+  - name: Computer
+    to: Event.System.Computer
+  - name: Service Name
+    to: Event.EventData.ServiceName
+  - name: Service File Name
+    to: Event.EventData.ImagePath
+  - name: Service Type
+    to: Event.EventData.ServiceType
+  - name: Service Start Type
+    to: Event.EventData.StartType  
+  - name: Service Account
+    to: Event.EventData.AccountName  
+
+filter:
+  condition: service_control_manager and service_name
+
+  service_control_manager:
+    Event.System.Provider: Service Control Manager
+    Event.System.EventID: 7045
+
+  service_name:
+    Event.EventData.ImagePath:
+      - 'i*cmd /c*'
+      - 'i*cmd /Q /c*'
+      - 'i*cmd.exe /c*'
+      - 'i*cmd.exe /Q /c*'
+      - 'i*%COMSPEC%*'

--- a/rules/service_installation/suspicious_paths.yml
+++ b/rules/service_installation/suspicious_paths.yml
@@ -1,0 +1,62 @@
+---
+title: Suspicious Paths Service Installation
+group: Service Installation 
+description: Suspicious Paths were found in a Service that Was Installed
+authors:
+  - reece394
+
+
+kind: evtx
+level: medium
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Record ID
+    to: Event.System.EventRecordID
+  - name: Computer
+    to: Event.System.Computer
+  - name: Service Name
+    to: Event.EventData.ServiceName
+  - name: Service File Name
+    to: Event.EventData.ImagePath
+  - name: Service Type
+    to: Event.EventData.ServiceType
+  - name: Service Start Type
+    to: Event.EventData.StartType  
+  - name: Service Account
+    to: Event.EventData.AccountName  
+
+filter:
+  condition: service_control_manager and service_name
+
+  service_control_manager:
+    Event.System.Provider: Service Control Manager
+    Event.System.EventID: 7045
+
+  service_name:
+    Event.EventData.ImagePath:
+      - 'i*\SystemRoot\*' # Could Produce False Positives
+      - 'i*\Perflogs\*'
+      - 'i*\Users\Public\*'
+      - 'i*\Windows\Temp\*'
+      - 'i*\AppData\*'
+      - 'i*\Temp\*'
+      - 'i*\Downloads\*'
+      - 'i*\Documents\*'
+      - 'i*\Music\*'
+      - 'i*\Desktop\*'
+      - 'i*\Favorites\*'
+      - 'i*\Links\*'
+      - 'i*\Favorites\*'
+      - 'i*\OneDrive\*'
+      - 'i*\Pictures\*'
+      - 'i*\Saved Games\*'
+      - 'i*\Videos\*'
+      - 'i?^[a-zA-Z]:\\.{1,16}\.exe$' # Could Produce False Positives
+      - 'i?^%SYSTEMROOT%\\.{1,16}\.exe$' # Could Produce False Positives
+      - 'i?^[a-zA-Z]:\\.{1,9}\.exe' # Could Produce False Positives
+      - 'i?^%SYSTEMROOT%\\.{1,9}\.exe' # Could Produce False Positives

--- a/rules/service_installation/sysinternals_psexec.yml
+++ b/rules/service_installation/sysinternals_psexec.yml
@@ -1,0 +1,46 @@
+---
+title: Sysinternals PsExec Service Installation
+group: Service Installation 
+description: A Sysinternals PsExec Service Was Installed
+authors:
+  - reece394
+
+
+kind: evtx
+level: medium
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Record ID
+    to: Event.System.EventRecordID
+  - name: Computer
+    to: Event.System.Computer
+  - name: Service Name
+    to: Event.EventData.ServiceName
+  - name: Service File Name
+    to: Event.EventData.ImagePath
+  - name: Service Type
+    to: Event.EventData.ServiceType
+  - name: Service Start Type
+    to: Event.EventData.StartType  
+  - name: Service Account
+    to: Event.EventData.AccountName  
+
+filter:
+  condition: service_control_manager and (service_name or image_path)
+
+  service_control_manager:
+    Event.System.Provider: Service Control Manager
+    Event.System.EventID: 7045
+
+  service_name:
+    Event.EventData.ServiceName:
+      - 'i*PSEXESVC*'
+
+  image_path:
+    Event.EventData.ImagePath:
+      - 'i*PSEXESVC.exe*'

--- a/rules/service_installation/tap0901.yml
+++ b/rules/service_installation/tap0901.yml
@@ -1,0 +1,46 @@
+---
+title: OpenVPN TAP Driver Service Installation
+group: Service Installation 
+description: An OpenVPN TAP Driver Service Was Installed
+authors:
+  - reece394
+
+
+kind: evtx
+level: medium
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Record ID
+    to: Event.System.EventRecordID
+  - name: Computer
+    to: Event.System.Computer
+  - name: Service Name
+    to: Event.EventData.ServiceName
+  - name: Service File Name
+    to: Event.EventData.ImagePath
+  - name: Service Type
+    to: Event.EventData.ServiceType
+  - name: Service Start Type
+    to: Event.EventData.StartType  
+  - name: Service Account
+    to: Event.EventData.AccountName  
+
+filter:
+  condition: service_control_manager and (service_name or image_path)
+
+  service_control_manager:
+    Event.System.Provider: Service Control Manager
+    Event.System.EventID: 7045
+
+  service_name:
+    Event.EventData.ServiceName:
+      - 'i*TAP-Windows*'
+
+  image_path:
+    Event.EventData.ImagePath:
+      - 'i*tap0901.sys*'


### PR DESCRIPTION
These are based on the sigma rules [here](https://github.com/SigmaHQ/sigma/tree/master/rules/windows/builtin/system/service_control_manager) with several adjustments made based on research specifically for these rules. 

Attached is a series of log files I used during my testing [EVTX_7045.zip](https://github.com/WithSecureLabs/chainsaw/files/13801226/EVTX_7045.zip). These were custom made in a virtual machine due to lack of samples available (Especially for Remote Access Tools) in addition to using the evtx samples from [Hayabusa-sample-evtx](https://github.com/Yamato-Security/Hayabusa-sample-evtx). Most of the rules are accounted for in these samples however some I relied on the docs for the tools to generate the rules. 

Thanks again for your assistance in #149 as without this I would have hit a brick wall. The only issue I had during testing and writing the rules is that sometimes the rules would not load. I believe this is because when I was testing I had blank space at the bottom of the file i.e. empty lines?/ potentially tab/padding issues. It would be nice to have the linter pick up on this when running the rule through lint if it is possible. 