### PR TITLE
McAfee, Trellix, Kaspersky and Microsoft Windows Security Essentials Rules

### DIFF
--- a/rules/antivirus/kaspersky.yml
+++ b/rules/antivirus/kaspersky.yml
@@ -29,3 +29,4 @@ filter:
   Event.System.Provider:
     - Real-time file protection
     - OnDemandScan
+    - avp

--- a/rules/antivirus/mcafee.yml
+++ b/rules/antivirus/mcafee.yml
@@ -1,0 +1,31 @@
+---
+title: McAfee and Trellix Endpoint
+group: Antivirus
+description: Events from McAfee and Trellix Endpoint Security.
+authors:
+  - Reece394
+
+
+kind: evtx
+level: critical
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Record ID
+    to: Event.System.EventRecordID
+  - name: Computer
+    to: Event.System.Computer
+  - name: Threat Name
+    to: Event.EventData.Data
+
+filter:
+  Event.System.Provider:
+    - McAfee Endpoint Security
+    - Trellix Endpoint Security
+  Event.System.EventID:
+  - 2 # Warning
+  - 3 # Error

--- a/rules/antivirus/windows_security_essentials.yml
+++ b/rules/antivirus/windows_security_essentials.yml
@@ -1,0 +1,46 @@
+---
+title: Windows Security Essentials
+group: Antivirus
+description: Events from Windows Security Essentials.
+authors:
+  - Reece394
+
+
+kind: evtx
+level: critical
+status: stable
+timestamp: Event.System.TimeCreated
+
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Record ID
+    to: Event.System.EventRecordID
+  - name: Computer
+    to: Event.System.Computer
+  - name: User
+    to: Event.EventData.Detection User
+  - name: Threat Name
+    to: Event.EventData.Data[7]
+  - name: Threat Path
+    to: Event.EventData.Data
+
+
+filter:
+  Event.System.Provider: Microsoft Antimalware
+  Event.System.EventID:
+  # Windows Security Essentials was observed using the same EventIDs as Microsoft Defender.
+  # From https://learn.microsoft.com/en-us/microsoft-365/security/defender-endpoint/troubleshoot-microsoft-defender-antivirus
+  - 1006 # The antimalware engine found malware or other potentially unwanted software.
+  - 1007 # The antimalware platform performed an action to protect your system from malware or other potentially unwanted software.
+  - 1008 # The antimalware platform attempted to perform an action to protect your system from malware or other potentially unwanted software, but the action failed.
+  - 1009 # The antimalware platform restored an item from quarantine.
+  - 1010 # The antimalware platform couldn't restore an item from quarantine.
+  - 1011 # The antimalware platform deleted an item from quarantine.
+  - 1012 # The antimalware platform couldn't delete an item from quarantine.
+  - 1015 # The antimalware platform detected suspicious behavior.
+  - 1116 # The antimalware platform detected malware or other potentially unwanted software.
+  - 1117 # The antimalware platform performed an action to protect your system from malware or other potentially unwanted software.
+  - 1118 # The antimalware platform attempted to perform an action to protect your system from malware or other potentially unwanted software, but the action failed.
+  - 1119 # The antimalware platform encountered a critical error when trying to take action on malware or other potentially unwanted software. There are more details in the event message.

--- a/rules/antivirus/windows_security_essentials.yml
+++ b/rules/antivirus/windows_security_essentials.yml
@@ -20,7 +20,7 @@ fields:
   - name: Computer
     to: Event.System.Computer
   - name: User
-    to: Event.EventData.Detection User
+    to: Event.EventData.Data[19]
   - name: Threat Name
     to: Event.EventData.Data[7]
   - name: Threat Path


### PR DESCRIPTION
Attached are rules for McAfee and Trellix Endpoint Security, Kaspersky Endpoint Security and Windows Security Essentials (It actually still gets Definition Updates shockingly!). 

Events for testing are attached [AV Test.zip](https://github.com/WithSecureLabs/chainsaw/files/13833610/AV.Test.zip)