### PR TITLE
feat: extend match_all option to tau patterns

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -184,7 +184,7 @@ enum Command {
         tau: bool,
     },
 
-    /// Search through forensic artefacts for keywords.
+    /// Search through forensic artefacts for keywords or patterns.
     Search {
         /// A string or regular expression pattern to search for.
         /// Not used when -e or -t is specified.
@@ -226,7 +226,7 @@ enum Command {
         #[arg(long = "local", group = "tz")]
         local: bool,
         /// Require all provided patterns to be found to constitute a match.
-        #[arg(long = "match_all", requires = "additional_pattern")]
+        #[arg(long = "match_all")]
         match_all: bool,
         /// The path to output results to.
         #[arg(short = 'o', long = "output")]
@@ -237,7 +237,8 @@ enum Command {
         /// Continue to search when an error is encountered.
         #[arg(long = "skip-errors")]
         skip_errors: bool,
-        /// Tau expressions to search with. e.g. 'Event.System.EventID: =4104'
+        /// Tau expressions to search with. e.g. 'Event.System.EventID: =4104'.
+        /// Multiple conditions are logical ORs unless the 'match_all' flag is specified
         #[arg(short = 't', long = "tau", number_of_values = 1)]
         tau: Option<Vec<String>>,
         /// The field that contains the timestamp.

--- a/src/search.rs
+++ b/src/search.rs
@@ -185,8 +185,10 @@ impl SearcherBuilder {
                 }
                 if expressions.is_empty() {
                     None
-                } else {
+                } else if match_all {
                     Some(Expression::BooleanGroup(BoolSym::And, expressions))
+                } else {
+                    Some(Expression::BooleanGroup(BoolSym::Or, expressions))
                 }
             }
             None => None,


### PR DESCRIPTION
Change the default behaviour when multiple tau rules are provided from logical AND to logical OR.
Extend the 'match_all' flag to toggle multiple tau rules from AND to OR conditions