### PR TITLE
fix: change default search behaviour to match_all

### DIFF
--- a/src/file/evtx.rs
+++ b/src/file/evtx.rs
@@ -64,16 +64,16 @@ impl<'a> Document for WrapperLegacy<'a> {
 }
 
 impl Searchable for SerializedEvtxRecord<Json> {
-    fn matches(&self, regex: &RegexSet, match_all: &bool) -> bool {
-        if *match_all {
+    fn matches(&self, regex: &RegexSet, match_any: &bool) -> bool {
+        if *match_any {
+            regex.is_match(&self.data.to_string().replace(r"\\", r"\"))
+        } else {
             regex
                 .matches(&self.data.to_string().replace(r"\\", r"\"))
                 .into_iter()
                 .collect::<Vec<_>>()
                 .len()
                 == regex.len()
-        } else {
-            regex.is_match(&self.data.to_string().replace(r"\\", r"\"))
         }
     }
 }

--- a/src/file/json.rs
+++ b/src/file/json.rs
@@ -53,16 +53,16 @@ impl Iterator for ParserIter {
 }
 
 impl Searchable for Json {
-    fn matches(&self, regex: &RegexSet, match_all: &bool) -> bool {
-        if *match_all {
+    fn matches(&self, regex: &RegexSet, match_any: &bool) -> bool {
+        if *match_any {
+            regex.is_match(&self.to_string().replace(r"\\", r"\"))
+        } else {
             regex
                 .matches(&self.to_string().replace(r"\\", r"\"))
                 .into_iter()
                 .collect::<Vec<_>>()
                 .len()
                 == regex.len()
-        } else {
-            regex.is_match(&self.to_string().replace(r"\\", r"\"))
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -225,9 +225,9 @@ enum Command {
         /// Output the timestamp using the local machine's timestamp.
         #[arg(long = "local", group = "tz")]
         local: bool,
-        /// Require all provided patterns to be found to constitute a match.
-        #[arg(long = "match_all")]
-        match_all: bool,
+        /// Require any of the provided patterns to be found to constitute a match.
+        #[arg(long = "match-any")]
+        match_any: bool,
         /// The path to output results to.
         #[arg(short = 'o', long = "output")]
         output: Option<PathBuf>,
@@ -238,7 +238,7 @@ enum Command {
         #[arg(long = "skip-errors")]
         skip_errors: bool,
         /// Tau expressions to search with. e.g. 'Event.System.EventID: =4104'.
-        /// Multiple conditions are logical ORs unless the 'match_all' flag is specified
+        /// Multiple conditions are logical ANDs unless the 'match-any' flag is specified
         #[arg(short = 't', long = "tau", number_of_values = 1)]
         tau: Option<Vec<String>>,
         /// The field that contains the timestamp.
@@ -805,7 +805,7 @@ fn run() -> Result<()> {
             jsonl,
             load_unknown,
             local,
-            match_all,
+            match_any,
             output,
             quiet,
             skip_errors,
@@ -880,7 +880,7 @@ fn run() -> Result<()> {
                 .load_unknown(load_unknown)
                 .local(local)
                 .skip_errors(skip_errors)
-                .match_all(match_all);
+                .match_any(match_any);
             if let Some(patterns) = additional_pattern {
                 searcher = searcher.patterns(patterns);
             } else if let Some(pattern) = pattern {

--- a/src/search.rs
+++ b/src/search.rs
@@ -118,7 +118,7 @@ impl<'a> Iterator for Iter<'a> {
                             return Some(Ok(evtx.data));
                         }
                     }
-                    if evtx.matches(&self.searcher.regex, &self.searcher.match_all) {
+                    if evtx.matches(&self.searcher.regex, &self.searcher.match_any) {
                         return Some(Ok(evtx.data));
                     }
                 }
@@ -135,7 +135,7 @@ impl<'a> Iterator for Iter<'a> {
                             return Some(Ok(json));
                         }
                     }
-                    if json.matches(&self.searcher.regex, &self.searcher.match_all) {
+                    if json.matches(&self.searcher.regex, &self.searcher.match_any) {
                         return Some(Ok(json));
                     }
                 }
@@ -146,7 +146,7 @@ impl<'a> Iterator for Iter<'a> {
 }
 
 pub trait Searchable {
-    fn matches(&self, regex: &RegexSet, match_all: &bool) -> bool;
+    fn matches(&self, regex: &RegexSet, match_any: &bool) -> bool;
 }
 
 #[derive(Default)]
@@ -157,7 +157,7 @@ pub struct SearcherBuilder {
     ignore_case: Option<bool>,
     load_unknown: Option<bool>,
     local: Option<bool>,
-    match_all: Option<bool>,
+    match_any: Option<bool>,
     skip_errors: Option<bool>,
     tau: Option<Vec<String>>,
     timestamp: Option<String>,
@@ -174,7 +174,7 @@ impl SearcherBuilder {
         let ignore_case = self.ignore_case.unwrap_or_default();
         let load_unknown = self.load_unknown.unwrap_or_default();
         let local = self.local.unwrap_or_default();
-        let match_all = self.match_all.unwrap_or_default();
+        let match_any = self.match_any.unwrap_or_default();
         let patterns = self.patterns.unwrap_or_default();
         let skip_errors = self.skip_errors.unwrap_or_default();
         let tau = match self.tau {
@@ -185,10 +185,10 @@ impl SearcherBuilder {
                 }
                 if expressions.is_empty() {
                     None
-                } else if match_all {
-                    Some(Expression::BooleanGroup(BoolSym::And, expressions))
-                } else {
+                } else if match_any {
                     Some(Expression::BooleanGroup(BoolSym::Or, expressions))
+                } else {
+                    Some(Expression::BooleanGroup(BoolSym::And, expressions))
                 }
             }
             None => None,
@@ -247,7 +247,7 @@ impl SearcherBuilder {
 
                 from,
                 load_unknown,
-                match_all,
+                match_any,
                 skip_errors,
                 tau,
                 timestamp: self.timestamp,
@@ -276,8 +276,8 @@ impl SearcherBuilder {
         self
     }
 
-    pub fn match_all(mut self, match_all: bool) -> Self {
-        self.match_all = Some(match_all);
+    pub fn match_any(mut self, match_any: bool) -> Self {
+        self.match_any = Some(match_any);
         self
     }
 
@@ -316,7 +316,7 @@ pub struct SearcherInner {
     regex: RegexSet,
 
     load_unknown: bool,
-    match_all: bool,
+    match_any: bool,
     from: Option<DateTime<Utc>>,
     skip_errors: bool,
     tau: Option<Expression>,


### PR DESCRIPTION
Flipping default behaviour to match_all, with a flag to match_any instead.