### PR TITLE
feature: MSSQL suspicious behavior rules

### DIFF
--- a/rules/service_tampering/mssql_sus_behavior.yml
+++ b/rules/service_tampering/mssql_sus_behavior.yml
@@ -5,7 +5,7 @@ authors:
   - 0xFFaraday
 
 kind: evtx
-level: high
+level: medium
 status: stable
 timestamp: Event.System.TimeCreated
 

--- a/rules/service_tampering/mssql_sus_behavior.yml
+++ b/rules/service_tampering/mssql_sus_behavior.yml
@@ -1,0 +1,26 @@
+title: Potential MSSQL Suspicious Activity
+group: Service Tampering
+description: General commands that could involve threat actor behavior
+authors:
+  - 0xFFaraday
+
+kind: evtx
+level: high
+status: stable
+timestamp: Event.System.TimeCreated
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Username
+    to: Event.System.Provider_attributes.Name
+  - name: Computer
+    to: Event.System.Computer
+  - name: Command
+    to: Event.EventData.Data
+
+filter:
+  condition: eventid
+
+  eventid:
+    Event.System.EventID: 15457

--- a/rules/service_tampering/xp_cmdshell_enabled.yml
+++ b/rules/service_tampering/xp_cmdshell_enabled.yml
@@ -5,7 +5,7 @@ authors:
   - 0xFFaraday
 
 kind: evtx
-level: critical
+level: high
 status: stable
 timestamp: Event.System.TimeCreated
 

--- a/rules/service_tampering/xp_cmdshell_enabled.yml
+++ b/rules/service_tampering/xp_cmdshell_enabled.yml
@@ -1,0 +1,34 @@
+title: MSSQL XP_CMDSHELL Enabled
+group: Service Tampering
+description: MSSQL being modified to allow command execution
+authors:
+  - 0xFFaraday
+
+kind: evtx
+level: critical
+status: stable
+timestamp: Event.System.TimeCreated
+
+fields:
+  - name: Event ID
+    to: Event.System.EventID
+  - name: Username
+    to: Event.System.Provider_attributes.Name
+  - name: Computer
+    to: Event.System.Computer
+  - name: Command
+    to: Event.EventData.Data[0]
+  - name: Old Value
+    to: Event.EventData.Data[1]
+  - name: New Value
+    to: Event.EventData.Data[2]
+
+filter:
+  condition: server_configuration and command_arguments
+
+  server_configuration:
+    Event.System.EventID: 15457
+    Event.EventData.Data[0]: "xp_cmdshell"
+  command_arguments:
+    Event.EventData.Data[1]: "0"
+    Event.EventData.Data[2]: "1"


### PR DESCRIPTION
This PR contains rules for the event ID '15457' for MSSQL. These rules have been highly successful in internal investigations where threat actors have exhibited this behavior. I hope anyone else utilizing chainsaw gets great value out of these rules! 

Screenshot below shows true positives of the rules firing:
![Screenshot 2024-09-22 at 10 53 13 AM](https://github.com/user-attachments/assets/5f7ced83-bb0e-4475-b5ca-115b8bbba7e8)

Please let me know if I need to change anything with this PR. Thanks!