### PR TITLE
More MFT Rules - Fix NTDS.DIT matching ADAMNTDS.DIT and Add Shadow Dumper and PSTools

### DIFF
--- a/rules/mft/adamntds_dit_mft.yml
+++ b/rules/mft/adamntds_dit_mft.yml
@@ -1,7 +1,7 @@
 ---
-title: NTDS.dit Suspicious Location
+title: ADAMNTDS.dit Suspicious Location
 group: MFT
-description: NTDS.dit in a different location than standard. Potential Dumping Activity.
+description: ADAMNTDS.dit in a different location than standard. Potential Dumping Activity.
 authors:
   - Reece394
 
@@ -35,19 +35,18 @@ fields:
     to: HasAlternateDataStreams
 
 filter:
-  condition: (ntds and ntds_1) and not ntds_2
+  condition: (adamntds and adamntds_1) and not adamntds_2
 
-  ntds:
+  adamntds:
     FullPath:
-      - 'i*ntds*'
+      - 'i*adamntds*'
 
-  ntds_1:
+  adamntds_1:
     FullPath:
       - 'i*.dit*'
 
-  ntds_2:
+  adamntds_2:
     FullPath:
-      - 'iWindows\NTDS\NTDS.dit'
+      - 'iProgram Files\Microsoft ADAM\*'
       - 'iWindows\WinSxS*'
       - 'iWindows\servicing\LCU\*'
-      - 'i*adamntds.dit*'

--- a/rules/mft/pstools_mft.yml
+++ b/rules/mft/pstools_mft.yml
@@ -1,0 +1,75 @@
+---
+title: PSTools
+group: MFT
+description: PSTools artifacts
+authors:
+  - Reece394
+
+
+kind: mft
+level: medium
+status: stable
+timestamp: StandardInfoCreated
+
+
+fields:
+  - name: FileNamePath
+    to: FullPath
+  - name: StandardInfoLastModified0x10
+    to: StandardInfoLastModified
+  - name: StandardInfoLastAccess0x10
+    to: StandardInfoLastAccess
+  - name: FileNameCreated0x30
+    to: FileNameCreated
+  - name: FileNameLastModified0x30
+    to: FileNameLastModified
+  - name: FileNameLastAccess0x30
+    to: FileNameLastAccess
+  - name: FileSize
+    to: FileSize
+  - name: IsADirectory
+    to: IsADirectory
+  - name: IsDeleted
+    to: IsDeleted
+  - name: HasAlternateDataStreams
+    to: HasAlternateDataStreams
+
+filter:
+  condition: pstools or (pstools_1 and pstools_2)
+
+  pstools:
+    FullPath:
+      - 'i*psfile.exe*'
+      - 'i*psfile64.exe*'
+      - 'i*PsGetsid.exe*'
+      - 'i*PsGetsid64.exe*'
+      - 'i*PsInfo.exe*'
+      - 'i*PsInfo64.exe*'
+      - 'i*pskill.exe*'
+      - 'i*pskill64.exe*'
+      - 'i*pslist.exe*'
+      - 'i*pslist64.exe*'
+      - 'i*PsLoggedon.exe*'
+      - 'i*PsLoggedon64.exe*'
+      - 'i*psloglist.exe*'
+      - 'i*psloglist64.exe*'
+      - 'i*pspasswd.exe*'
+      - 'i*pspasswd64.exe*'
+      - 'i*psping.exe*'
+      - 'i*psping64.exe*'
+      - 'i*PsService.exe*'
+      - 'i*PsService64.exe*'
+      - 'i*psshutdown.exe*'
+      - 'i*psshutdown64.exe*'
+      - 'i*pssuspend.exe*'
+      - 'i*pssuspend64.exe*'
+      - 'i*Pstools.chm*'
+      - 'i*psversion.txt*'
+
+  pstools_1:
+    FullPath:
+      - 'i*PSTools*'
+
+  pstools_2:
+    FullPath:
+      - 'i*.zip*'

--- a/rules/mft/shadow_dumper_mft.yml
+++ b/rules/mft/shadow_dumper_mft.yml
@@ -1,13 +1,13 @@
 ---
-title: NTDS.dit Suspicious Location
+title: ShadowDumper
 group: MFT
-description: NTDS.dit in a different location than standard. Potential Dumping Activity.
+description: ShadowDumper artifacts
 authors:
   - Reece394
 
 
 kind: mft
-level: medium
+level: critical
 status: stable
 timestamp: StandardInfoCreated
 
@@ -35,19 +35,17 @@ fields:
     to: HasAlternateDataStreams
 
 filter:
-  condition: (ntds and ntds_1) and not ntds_2
+  condition: shadowdumper
 
-  ntds:
+  shadowdumper:
     FullPath:
-      - 'i*ntds*'
-
-  ntds_1:
-    FullPath:
-      - 'i*.dit*'
-
-  ntds_2:
-    FullPath:
-      - 'iWindows\NTDS\NTDS.dit'
-      - 'iWindows\WinSxS*'
-      - 'iWindows\servicing\LCU\*'
-      - 'i*adamntds.dit*'
+      - 'i*PANDA.txt*'
+      - 'i*simpleMDWD.raw*'
+      - 'i*sysMDWD.file*'
+      - 'i*panda.raw*'
+      - 'i*panda.sense*'
+      - 'i*panda.enc*'
+      - 'i*ShadowDumper*'
+      - 'i*off.bin*'
+      - 'i*pan.bin*'
+      - 'i*callback.elf*'


### PR DESCRIPTION
Some more MFT rules. I attempted to further reduce the false positive entries for NTDS.DIT. 
ADAMNTDS.DIT can be abused too so created a separate rule for that based on [here](https://www.synacktiv.com/en/publications/using-ntdissector-to-extract-secrets-from-adam-ntds-files). 
Also added Shadow Dumper support from [here](https://github.com/Offensive-Panda/ShadowDumper). 
Also added the rest of the PSTools folder as this frequently pops up