### PR TITLE
nix flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704842529,
-        "narHash": "sha256-OTeQA+F8d/Evad33JMfuXC89VMetQbsU4qcaePchGr4=",
+        "lastModified": 1732937961,
+        "narHash": "sha256-B5pYT+IVaqcrfOekkwKvx/iToDnuQWzc2oyDxzzBDc4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "eabe8d3eface69f5bb16c18f8662a702f50c20d5",
+        "rev": "4703b8d2c708e13a8cab03d865f90973536dcdf5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
           rustc
           rustfmt
           vscode-extensions.llvm-org.lldb-vscode
+          inputs.self.packages.${system}.chainsaw
         ];
 
         RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
@@ -31,7 +32,7 @@
     in {
       chainsaw = pkgs.rustPlatform.buildRustPackage {
         pname = "chainsaw";
-        version = "2.8.1";
+        version = "2.10.1";
 
         src = ./.;
 


### PR DESCRIPTION
this introduces a hotfix for https://github.com/WithSecureLabs/chainsaw/issues/199 

as well as utilized `nix flake update`  to bump input version of nixpkgs for the flake 