### PR TITLE
Add Netscan and Advanced Port Scanner and Modify WinSCP and Advanced IP Scanner MFT Rules

### DIFF
--- a/rules/mft/advanced_ip_scanner_mft.yml
+++ b/rules/mft/advanced_ip_scanner_mft.yml
@@ -35,7 +35,7 @@ fields:
     to: HasAlternateDataStreams
 
 filter:
-  condition: ais and (ais_1 or ais_2 or ais_3)
+  condition: ais and (ais_1 or ais_2 or ais_3 or ais_4)
 
   ais:
     FullPath:
@@ -51,5 +51,9 @@ filter:
       - 'i*.bin*'
 
   ais_3:
+    FullPath:
+      - 'i*mac_interval_tree.txt*'
+
+  ais_4:
     FullPath:
       - 'i*.lnk*'

--- a/rules/mft/advanced_port_scanner_mft.yml
+++ b/rules/mft/advanced_port_scanner_mft.yml
@@ -1,7 +1,7 @@
 ---
-title: WinSCP
+title: Advanced Port Scanner
 group: MFT
-description: WinSCP artifacts
+description: Advanced Port Scanner artifacts
 authors:
   - Reece394
 
@@ -35,20 +35,25 @@ fields:
     to: HasAlternateDataStreams
 
 filter:
-  condition: winscp and (winscp_1 or winscp_2 or winscp_3)
+  condition: aps and (aps_1 or aps_2 or aps_3 or aps_4)
 
-  winscp:
+  aps:
     FullPath:
-      - 'i*winscp*'
+      - 'i*advanced_port_scanner*'
+      - 'i*advanced port scanner*'
 
-  winscp_1:
-    FullPath:
-      - 'i*.ini*'
-
-  winscp_2:
+  aps_1:
     FullPath:
       - 'i*.exe*'
 
-  winscp_3:
+  aps_2:
     FullPath:
-      - 'i*.rnd*'
+      - 'i*.bin*'
+
+  aps_3:
+    FullPath:
+      - 'i*mac_interval_tree.txt*'
+
+  aps_4:
+    FullPath:
+      - 'i*.lnk*'

--- a/rules/mft/netscan_mft.yml
+++ b/rules/mft/netscan_mft.yml
@@ -1,7 +1,7 @@
 ---
-title: WinSCP
+title: SoftPerfect Network Scanner - Netscan
 group: MFT
-description: WinSCP artifacts
+description: SoftPerfect Network Scanner - Netscan artifacts
 authors:
   - Reece394
 
@@ -35,20 +35,21 @@ fields:
     to: HasAlternateDataStreams
 
 filter:
-  condition: winscp and (winscp_1 or winscp_2 or winscp_3)
+  condition: netscan and (netscan_1 or netscan_2 or netscan_3)
 
-  winscp:
+  netscan:
     FullPath:
-      - 'i*winscp*'
+      - 'i*netscan*'
+      - 'i*SoftPerfect Network Scanner*'
 
-  winscp_1:
-    FullPath:
-      - 'i*.ini*'
-
-  winscp_2:
+  netscan_1:
     FullPath:
       - 'i*.exe*'
 
-  winscp_3:
+  netscan_2:
     FullPath:
-      - 'i*.rnd*'
+      - 'i*.lic*'
+
+  netscan_3:
+    FullPath:
+      - 'i*.xml*'


### PR DESCRIPTION
Turns out Advanced Port Scanner and Advanced IP Scanner share a lot of the same code when running the latest versions in a VM. This allowed me to spot common themes between the two including something I missed on the original MFT rule to help identify presence. I could have included .qm and .tpl files but these were a bit noisy and unlikely to make much difference keeping them in. 

Additionally added the .rnd WinSCP random seed file to the WinSCP rule and added a Netscan rule to cover this tool which is another commonly abused tool on cases.