### PR TITLE
feat(dump) - extract, decode and write MFT streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
  "predicates",
  "prettytable-rs",
  "quick-xml 0.37.1",
+ "rand",
  "rayon",
  "regex",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ once_cell = "1.0"
 prettytable-rs = "0.10"
 quick-xml = { version = "0.37", features = ["serialize"] }
 rayon = "1.5"
+rand = "0.8"
 regex = "1.6"
 rustc-hash = "2.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/file/mft.rs
+++ b/src/file/mft.rs
@@ -1,30 +1,213 @@
-use std::path::Path;
-use std::{fs::File, io::BufReader};
+use std::io::{BufReader, Write};
+use std::path::{self, Path, PathBuf};
+use std::{fs::create_dir_all, fs::File, ops::RangeInclusive, str::FromStr};
 
-use mft::csv::FlatMftEntryWithName;
-use mft::MftParser;
-use serde_json::Value as Json;
+use anyhow::{anyhow, Error, Result};
+use mft::{
+    attribute::MftAttributeType,
+    csv::FlatMftEntryWithName,
+    entry::{MftEntry, ZERO_HEADER},
+    MftParser,
+};
+use serde::Serialize;
+use serde_json::{json, Value as Json};
 
 pub type Mft = Json;
 
 pub struct Parser {
     pub inner: MftParser<BufReader<File>>,
+    ranges: Option<Ranges>,
+    pub data_streams_directory: Option<PathBuf>,
+    pub decode_data_streams: bool,
+}
+
+#[derive(Serialize)]
+struct DataStreams {
+    stream_name: String,
+    stream_number: usize,
+    stream_data: String,
+}
+
+struct Ranges(Vec<RangeInclusive<usize>>);
+
+impl Ranges {
+    pub fn chain(&self) -> impl Iterator<Item = usize> + '_ {
+        self.0.iter().cloned().flatten()
+    }
+}
+
+impl FromStr for Ranges {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let mut ranges = vec![];
+        for x in s.split(',') {
+            // range
+            if x.contains('-') {
+                let range: Vec<&str> = x.split('-').collect();
+                if range.len() != 2 {
+                    return Err(anyhow!(
+                        "Failed to parse ranges: Range should contain exactly one `-`, found {}",
+                        x
+                    ));
+                }
+
+                ranges.push(range[0].parse()?..=range[1].parse()?);
+            } else {
+                let n = x.parse()?;
+                ranges.push(n..=n);
+            }
+        }
+
+        Ok(Ranges(ranges))
+    }
 }
 
 impl Parser {
-    pub fn load(file: &Path) -> crate::Result<Self> {
+    pub fn load(
+        file: &Path,
+        data_streams_directory: Option<PathBuf>,
+        decode_data_streams: bool,
+    ) -> crate::Result<Self> {
         let parser = MftParser::from_path(file)?;
-        Ok(Self { inner: parser })
+        Ok(Self {
+            inner: parser,
+            ranges: None,
+            data_streams_directory,
+            decode_data_streams,
+        })
     }
 
     pub fn parse(&mut self) -> impl Iterator<Item = crate::Result<Json>> + '_ {
-        // FIXME: Due to the nested borrowing we still have to do a full pass which is memory
-        // hungry but there is no easy way around this for now...
-        let entries = self.inner.iter_entries().collect::<Vec<_>>();
-        entries.into_iter().map(|e| match e {
-            Ok(e) => serde_json::to_value(FlatMftEntryWithName::from_entry(&e, &mut self.inner))
-                .map_err(|e| e.into()),
-            Err(e) => anyhow::bail!(e),
+        // Code is adapted MFT Library implementation of the mft_dump.rs file
+        // Reference: https://github.com/omerbenamram/mft/blob/6767bb5d3787b5532a7a5a07532f0c6b4e22413d/src/bin/mft_dump.rs#L289
+
+        if let Some(data_streams_dir) = &self.data_streams_directory {
+            if !data_streams_dir.exists() {
+                create_dir_all(data_streams_dir).expect("Failed to create data streams directory");
+            }
+        }
+
+        let number_of_entries = self.inner.get_entry_count();
+
+        let take_ranges = self.ranges.take();
+
+        let entries = match take_ranges {
+            Some(ref ranges) => Box::new(ranges.chain()),
+            None => Box::new(0..number_of_entries as usize) as Box<dyn Iterator<Item = usize>>,
+        };
+
+        let collected_entries: Vec<_> = entries
+            .filter_map(|i| {
+                let entry = self.inner.get_entry(i as u64);
+                match entry {
+                    Ok(entry) => match &entry.header.signature {
+                        // Skip entries with zero headers
+                        ZERO_HEADER => None,
+                        _ => Some(entry),
+                    },
+                    Err(error) => {
+                        cs_eyellowln!("{}", error);
+                        None
+                    }
+                }
+            })
+            .collect();
+
+        collected_entries.into_iter().map(|e| {
+            // Get the MFT entry base details from the entry using FlatMftEntryWithName
+            match serde_json::to_value(FlatMftEntryWithName::from_entry(&e, &mut self.inner)) {
+                Ok(mut val) => {
+                    // Extract the DataStreams from the MFT entry
+                    val["DataStreams"] = extract_data_streams(self, &e)?;
+                    Ok(val)
+                }
+                Err(e) => Err(anyhow::Error::from(e)),
+            }
         })
     }
+}
+
+pub fn extract_data_streams(parser: &mut Parser, entry: &MftEntry) -> crate::Result<Json> {
+    // This function is used to extract the data streams from the MFT entry.
+    // It will attempt to write the data streams to the output path if provided.
+    // It will attempt to decode the data streams if the decode_data_streams flag is set.
+
+    // Code is based on the MFT Library implementation of the mft_dump.rs file
+    // Reference: https://github.com/omerbenamram/mft/blob/6767bb5d3787b5532a7a5a07532f0c6b4e22413d/src/bin/mft_dump.rs#L289
+
+    let mut data_streams = vec![];
+
+    for (i, (name, stream)) in entry
+        .iter_attributes()
+        .filter_map(|a| a.ok())
+        .filter_map(|a| {
+            if a.header.type_code == MftAttributeType::DATA {
+                let name = a.header.name.clone();
+                a.data.into_data().map(|data| (name, data))
+            } else {
+                None
+            }
+        })
+        .enumerate()
+    {
+        if let Some(data_streams_dir) = &parser.data_streams_directory {
+            if let Some(path) = parser.inner.get_full_path_for_entry(entry)? {
+                // Replace file path seperators with underscores
+
+                let sanitized_path = path
+                    .to_string_lossy()
+                    .chars()
+                    .map(|c| if path::is_separator(c) { '_' } else { c })
+                    .collect::<String>();
+
+                let output_path: String = data_streams_dir
+                    .join(&sanitized_path)
+                    .to_string_lossy()
+                    .to_string();
+
+                // Generate 6 characters random hex string
+                let random: String = (0..6)
+                    .map(|_| format!("{:02x}", rand::random::<u8>()))
+                    .fold(String::new(), |acc, hex| format!("{}{}", acc, hex));
+
+                let truncated: String = output_path.chars().take(150).collect();
+
+                if PathBuf::from(&output_path).exists() {
+                    return Err(anyhow!(
+                        "Data stream output path already exists: {}\n\
+                        Exiting out of precaution.",
+                        output_path
+                    ));
+                }
+
+                File::create(format!(
+                    "{path}__{random}_{stream_number}_{stream_name}.disabled",
+                    path = truncated,
+                    random = random,
+                    stream_number = i,
+                    stream_name = name
+                ))?
+                .write_all(stream.data())?;
+            }
+        }
+
+        //convert stream.data() to a hex string
+        let final_data_stream = if parser.decode_data_streams {
+            String::from_utf8_lossy(stream.data()).to_string()
+        } else {
+            stream
+                .data()
+                .iter()
+                .map(|byte| format!("{:02x}", byte))
+                .fold(String::new(), |acc, hex| format!("{}{}", acc, hex))
+        };
+
+        data_streams.push(DataStreams {
+            stream_name: name,
+            stream_number: i,
+            stream_data: final_data_stream,
+        });
+    }
+    Ok(json!(data_streams))
 }

--- a/src/hunt.rs
+++ b/src/hunt.rs
@@ -774,7 +774,14 @@ impl Hunter {
         file: &'a Path,
         cache: &Option<std::fs::File>,
     ) -> crate::Result<Vec<Detections<'a>>> {
-        let mut reader = Reader::load(file, self.inner.load_unknown, self.inner.skip_errors)?;
+        let mut reader = Reader::load(
+            file,
+            self.inner.load_unknown,
+            self.inner.skip_errors,
+            true,
+            None,
+        )?;
+
         let kind = reader.kind();
         #[allow(clippy::type_complexity)]
         let aggregates: Mutex<

--- a/src/search.rs
+++ b/src/search.rs
@@ -334,7 +334,13 @@ impl Searcher {
     }
 
     pub fn search(&self, file: &Path) -> crate::Result<Hits<'_>> {
-        let reader = Reader::load(file, self.inner.load_unknown, self.inner.skip_errors)?;
+        let reader = Reader::load(
+            file,
+            self.inner.load_unknown,
+            self.inner.skip_errors,
+            true,
+            None,
+        )?;
         Ok(Hits {
             reader,
             searcher: &self.inner,


### PR DESCRIPTION
### Overview

Our current MFT support doesn't look at data streams stored in MFT entries. These data streams are a goldmine of information for Incident Responders. 

This PR aims to introduce three key features:

1. Chainsaw is able to extract MFT data streams, decode them and include them in the YAML and JSON outputs.
2. Chainsaw is able to extract MFT data streams, decode them and write them to disk
3. Chainsaw is able to apply detection logic to data streams

This PR should address issues: #190 #191 

### Examples

#### Data Streams in YAML Output

By default, Chainsaw will now extract data streams and include them in the default output. Stream names and values are shown, with values being in a hexstring format:

```
➜  release ./chainsaw dump ~/Artefacts/MFT/Win10/APTSimulatorVM/\$MFT
 ██████╗██╗  ██╗ █████╗ ██╗███╗   ██╗███████╗ █████╗ ██╗    ██╗
██╔════╝██║  ██║██╔══██╗██║████╗  ██║██╔════╝██╔══██╗██║    ██║
██║     ███████║███████║██║██╔██╗ ██║███████╗███████║██║ █╗ ██║
██║     ██╔══██║██╔══██║██║██║╚██╗██║╚════██║██╔══██║██║███╗██║
╚██████╗██║  ██║██║  ██║██║██║ ╚████║███████║██║  ██║╚███╔███╔╝
 ╚═════╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝
    By WithSecure Countercept (@FranticTyping, @AlexKornitzer)

[+] Dumping the contents of forensic artefacts from: ~/Artefacts/MFT/Win10/APTSimulatorVM/\$MFT(extensions: *)
[+] Loaded 1 forensic artefacts (274.2 MB)
<snip>

Signature: FILE
EntryId: 110351
Sequence: 1
BaseEntryId: 0
BaseEntrySequence: 0
HardLinkCount: 2
Flags: ALLOCATED
UsedEntrySize: 1000
TotalEntrySize: 1024
FileSize: 418
IsADirectory: false
IsDeleted: false
HasAlternateDataStreams: true
StandardInfoFlags: FILE_ATTRIBUTE_ARCHIVE
StandardInfoLastModified: 2022-03-10T19:49:34.904995Z
StandardInfoLastAccess: 2022-03-10T19:49:35.460937Z
StandardInfoCreated: 2018-04-09T17:46:18Z
FileNameFlags: FILE_ATTRIBUTE_ARCHIVE
FileNameLastModified: 2022-03-10T19:49:34.892970Z
FileNameLastAccess: 2022-03-10T19:49:34.892970Z
FileNameCreated: 2022-03-10T19:49:34.892970Z
FullPath: Users/TestUser/Downloads/APTSimulator_pw_apt/dist/APTSimulator/test-sets/persistence/web-shells.bat
DataStreams:
- stream_name: ''
  stream_number: 0
  stream_data: 404543484f204f46460a0a4543484f203d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d0a4543484f205745425348454c4c530a4543484f2044726f7070696e6720776562207368656c6c20696e206e657720575757206469726563746f72790a70696e67202d6e2035203132372e302e302e31203e204e554c0a0a4d4b444952202225575757524f4f5425220a22255a495025222065202d70255041535325202225544f4f4c415243482522202d616f61202d6f2225575757524f4f54252220746f6f6c7365745c622e6a7370203e204e554c0a22255a495025222065202d70255041535325202225544f4f4c415243482522202d616f61202d6f2225575757524f4f54252220746f6f6c7365745c74657374732e6a7370203e204e554c0a22255a495025222065202d70255041535325202225544f4f4c415243482522202d616f61202d6f2225575757524f4f54252220746f6f6c7365745c7368656c6c2e676966203e204e554c0a
- stream_name: Zone.Identifier
  stream_number: 1
  stream_data: 00005b5a6f6e655472616e736665725d0d0a5a6f6e6549643d330d0a526566657272657255726c3d433a5c55736572735c54657374557365725c446f776e6c6f6164735c41505453696d756c61746f725f70775f6170742e7a6970
```

#### Data Streams in YAML Output with Decoding

The chainsaw dump module now has the `--decode-data-streams` flag which will ask chainsaw to attempt to decode data streams before outputting them. This is *super* useful for quickly identifying Zone.Identifiers and the contents of files (if resident)

```
➜  release ./chainsaw dump ~/Artefacts/MFT/Win10/APTSimulatorVM/\$MFT --decode-data-streams
 ██████╗██╗  ██╗ █████╗ ██╗███╗   ██╗███████╗ █████╗ ██╗    ██╗
██╔════╝██║  ██║██╔══██╗██║████╗  ██║██╔════╝██╔══██╗██║    ██║
██║     ███████║███████║██║██╔██╗ ██║███████╗███████║██║ █╗ ██║
██║     ██╔══██║██╔══██║██║██║╚██╗██║╚════██║██╔══██║██║███╗██║
╚██████╗██║  ██║██║  ██║██║██║ ╚████║███████║██║  ██║╚███╔███╔╝
 ╚═════╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝
    By WithSecure Countercept (@FranticTyping, @AlexKornitzer)

[+] Dumping the contents of forensic artefacts from: ~/Artefacts/MFT/Win10/APTSimulatorVM/\$MFT (extensions: *)
[+] Loaded 1 forensic artefacts (274.2 MB)

<snip>
EntryId: 110351
Sequence: 1
BaseEntryId: 0
BaseEntrySequence: 0
HardLinkCount: 2
Flags: ALLOCATED
UsedEntrySize: 1000
TotalEntrySize: 1024
FileSize: 418
IsADirectory: false
IsDeleted: false
HasAlternateDataStreams: true
StandardInfoFlags: FILE_ATTRIBUTE_ARCHIVE
StandardInfoLastModified: 2022-03-10T19:49:34.904995Z
StandardInfoLastAccess: 2022-03-10T19:49:35.460937Z
StandardInfoCreated: 2018-04-09T17:46:18Z
FileNameFlags: FILE_ATTRIBUTE_ARCHIVE
FileNameLastModified: 2022-03-10T19:49:34.892970Z
FileNameLastAccess: 2022-03-10T19:49:34.892970Z
FileNameCreated: 2022-03-10T19:49:34.892970Z
FullPath: Users/TestUser/Downloads/APTSimulator_pw_apt/dist/APTSimulator/test-sets/persistence/web-shells.bat
DataStreams:
- stream_name: ''
  stream_number: 0
  stream_data: |
    @ECHO OFF

    ECHO ===========================================================================
    ECHO WEBSHELLS
    ECHO Dropping web shell in new WWW directory
    ping -n 5 127.0.0.1 > NUL

    MKDIR "%WWWROOT%"
    "%ZIP%" e -p%PASS% "%TOOLARCH%" -aoa -o"%WWWROOT%" toolset\b.jsp > NUL
    "%ZIP%" e -p%PASS% "%TOOLARCH%" -aoa -o"%WWWROOT%" toolset\tests.jsp > NUL
    "%ZIP%" e -p%PASS% "%TOOLARCH%" -aoa -o"%WWWROOT%" toolset\shell.gif > NUL
- stream_name: Zone.Identifier
  stream_number: 1
  stream_data: "\0\0[ZoneTransfer]\r\nZoneId=3\r\nReferrerUrl=C:\\Users\\TestUser\\Downloads\\APTSimulator_pw_apt.zip"
```

### Writing Data Streams to Disk

Chainsaw now has the option to write extracted and decoded data streams to disk via the `--data-streams-directory` option

```
➜ ./chainsaw dump ~/Artefacts/MFT/Win10/APTSimulatorVM/\$MFT --data-streams-directory ./datastreams

 ██████╗██╗  ██╗ █████╗ ██╗███╗   ██╗███████╗ █████╗ ██╗    ██╗
██╔════╝██║  ██║██╔══██╗██║████╗  ██║██╔════╝██╔══██╗██║    ██║
██║     ███████║███████║██║██╔██╗ ██║███████╗███████║██║ █╗ ██║
██║     ██╔══██║██╔══██║██║██║╚██╗██║╚════██║██╔══██║██║███╗██║
╚██████╗██║  ██║██║  ██║██║██║ ╚████║███████║██║  ██║╚███╔███╔╝
 ╚═════╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝
    By WithSecure Countercept (@FranticTyping, @AlexKornitzer)

[+] Dumping the contents of forensic artefacts from: ~/Artefacts/MFT/Win10/APTSimulatorVM/\$MFT (extensions: *)
[+] Loaded 1 forensic artefacts (274.2 MB)
<snip>

➜  ls ./datastreams | tail -n 3
[Unknown]__edb7a20a758b_0_.disabled
[Unknown]__f7776040c557_1_.disabled
inetpub_wwwroot_tests.jsp__ed4158d930f8_0_.disabled
```

### Hunting on the content of DataStreams

Now that chainsaw extracts MFT datastreams we can write powerful detection rules on them:
```
➜  cat /tmp/mft_rule/mimikatz_datastream_ref.yml
---
title: Mimikatz DataStream Reference
group: MFT
description: Look for mimikatz strings in data stream content
authors:
  - FranticTyping

kind: mft
level: critical
status: stable
timestamp: StandardInfoCreated


fields:
  - name: FileNamePath
    to: FullPath
  - name: FileSize
    to: FileSize
  - name: IsADirectory
    to: IsADirectory
  - name: IsDeleted
    to: IsDeleted
  - name: HasAlternateDataStreams
    to: HasAlternateDataStreams
  - name: DataStreams
    to: DataStreams

filter:
  condition: mimikatz

  mimikatz:
    DataStreams:
      - stream_data: i*mimi*
```
Leading to:

```
./chainsaw hunt /tmp/mft_rule ~/Artfacts/MFT/Win10/APTSimulatorVM/\$MFT

 ██████╗██╗  ██╗ █████╗ ██╗███╗   ██╗███████╗ █████╗ ██╗    ██╗
██╔════╝██║  ██║██╔══██╗██║████╗  ██║██╔════╝██╔══██╗██║    ██║
██║     ███████║███████║██║██╔██╗ ██║███████╗███████║██║ █╗ ██║
██║     ██╔══██║██╔══██║██║██║╚██╗██║╚════██║██╔══██║██║███╗██║
╚██████╗██║  ██║██║  ██║██║██║ ╚████║███████║██║  ██║╚███╔███╔╝
 ╚═════╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝
    By WithSecure Countercept (@FranticTyping, @AlexKornitzer)

[+] Loading detection rules from: /tmp/mft_rule
[+] Loading forensic artefacts from: ~/Artefacts/MFT/Win10/APTSimulatorVM/\$MFT (extensions: .$MFT, .mft, .bin)
[+] Loaded 1 forensic artefacts (274.2 MB)
[+] Current Artefact: ~/Artefacts/MFT/Win10/APTSimulatorVM/\$MFT
[+] Hunting [========================================] 1/1   [00:00:02]
[+] Group: MFT
┌───────────────────────────┬─────────────────────────────────┬────────────────────────────────────────────────────┬──────────┬──────────────┬───────────┬─────────────────────────┬────────────────────────────────────────────────────┐
│         timestamp         │           detections            │                    FileNamePath                    │ FileSize │ IsADirectory │ IsDeleted │ HasAlternateDataStreams │                    DataStreams                     │
├───────────────────────────┼─────────────────────────────────┼────────────────────────────────────────────────────┼──────────┼──────────────┼───────────┼─────────────────────────┼────────────────────────────────────────────────────┤
│ 2018-03-02 03:31:02+00:00 │ ‣ Mimikatz DataStream Reference │ Users/TestUser/Downloads/APTSimulator_pw_apt/APTSi │ 242      │ false        │ false     │ true                    │ - stream_name: ''                                  │
│                           │                                 │ mulator/test-sets/persistence/at-jobs.bat          │          │              │           │                         │  stream_data: |                                    │
│                           │                                 │                                                    │          │              │           │                         │   @ECHO OFF                                        │
│                           │                                 │                                                    │          │              │           │                         │                                                    │
│                           │                                 │                                                    │          │              │           │                         │   ECHO =========================================== │
│                           │                                 │                                                    │          │              │           │                         │ ================================                   │
│                           │                                 │                                                    │          │              │           │                         │   ECHO At Job Creation                             │
│                           │                                 │                                                    │          │              │           │                         │   ECHO Registering mimikatz in At job              │
│                           │                                 │                                                    │          │              │           │                         │   ping -n 5 127.0.0.1 > NUL                        │
│                           │                                 │                                                    │          │              │           │                         │                                                    │
│                           │                                 │                                                    │          │              │           │                         │   at 13:00 "C:\TMP\mim.exe sekurlsa::LogonPassword │
│                           │                                 │                                                    │          │              │           │                         │ s > C:\TMP\o.txt"                                  │
│                           │                                 │                                                    │          │              │           │                         │  stream_number: 0                                  │
│                           │                                 │                                                    │          │              │           │                         │ - stream_name: Zone.Identifier                     │
│                           │                                 │                                                    │          │              │           │                         │  stream_data: "\0\0[ZoneTransfer]\r\nZoneId=3\r\nR │
│                           │                                 │                                                    │          │              │           │                         │ eferrerUrl=C:\\Users\\TestUser\\Downloads\\APTSimu │
│                           │                                 │                                                    │          │              │           │                         │ lator_pw_apt.zip"                                  │
│                           │                                 │                                                    │          │              │           │                         │  stream_number: 1                                  │
├───────────────────────────┼─────────────────────────────────┼────────────────────────────────────────────────────┼──────────┼──────────────┼───────────┼─────────────────────────┼────────────────────────────────────────────────────┤
│ 2018-03-02 03:31:14+00:00 │ ‣ Mimikatz DataStream Reference │ Users/TestUser/Downloads/APTSimulator_pw_apt/APTSi │ 297      │ false        │ false     │ true                    │ - stream_name: ''                                  │
│                           │                                 │ mulator/test-sets/persistence/schtasks.bat         │          │              │           │                         │  stream_data: |                                    │
│                           │                                 │                                                    │          │              │           │                         │   @ECHO OFF                                        │
│                           │                                 │                                                    │          │              │           │                         │                                                    │
│                           │                                 │                                                    │          │              │           │                         │   ECHO =========================================== │
│                           │                                 │                                                    │          │              │           │                         │ ================================                   │
│                           │                                 │                                                    │          │              │           │                         │   ECHO Schtasks Creation                           │
│                           │                                 │                                                    │          │              │           │                         │   ECHO Registering mimikatz in scheduled task      │
│                           │                                 │                                                    │          │              │           │                         │   ping -n 5 127.0.0.1 > NUL                        │
│                           │                                 │                                                    │          │              │           │                         │                                                    │
│                           │                                 │                                                    │          │              │           │                         │   schtasks /create /f /sc minute /mo 5 /tn GameOve │
│                           │                                 │                                                    │          │              │           │                         │ r /tr "C:\TMP\mim.exe sekurlsa::LogonPasswords > C │
│                           │                                 │                                                    │          │              │           │                         │ :\TMP\o.txt"                                       │
│                           │                                 │                                                    │          │              │           │                         │  stream_number: 0                                  │
│                           │                                 │                                                    │          │              │           │                         │ - stream_name: Zone.Identifier                     │
│                           │                                 │                                                    │          │              │           │                         │  stream_data: "\0\0[ZoneTransfer]\r\nZoneId=3\r\nR │
│                           │                                 │                                                    │          │              │           │                         │ eferrerUrl=C:\\Users\\TestUser\\Downloads\\APTSimu │
│                           │                                 │                                                    │          │              │           │                         │ lator_pw_apt.zip"                                  │
│                           │                                 │                                                    │          │              │           │                         │  stream_number: 1                                  │
├───────────────────────────┼─────────────────────────────────┼────────────────────────────────────────────────────┼──────────┼──────────────┼───────────┼─────────────────────────┼────────────────────────────────────────────────────┤
```