### PR TITLE
MFT Library Fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ hex = "0.4.3"
 indicatif = "0.17"
 lazy_static = "1.4.0"
 libesedb = "0.2.4"
-mft = { git = "https://github.com/reece394/mft.git" , rev = "f462549" } # modified fork
+mft = { git = "https://github.com/reece394/mft.git" , rev = "9b1dbef" } # modified fork
 notatin = "1.0"
 once_cell = "1.0"
 prettytable-rs = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ hex = "0.4.3"
 indicatif = "0.17"
 lazy_static = "1.4.0"
 libesedb = "0.2.4"
-mft = "0.6"
+mft = { git = "https://github.com/reece394/mft.git" , rev = "f462549" } # modified fork
 notatin = "1.0"
 once_cell = "1.0"
 prettytable-rs = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ hex = "0.4.3"
 indicatif = "0.17"
 lazy_static = "1.4.0"
 libesedb = "0.2.4"
-mft = { git = "https://github.com/reece394/mft.git" , rev = "9b1dbef" } # modified fork
+mft = { git = "https://github.com/reece394/mft.git" , rev = "865549c" } # modified fork
 notatin = "1.0"
 once_cell = "1.0"
 prettytable-rs = "0.10"

--- a/src/file/mft.rs
+++ b/src/file/mft.rs
@@ -156,7 +156,7 @@ pub fn extract_data_streams(parser: &mut Parser, entry: &MftEntry) -> crate::Res
                 // Replace file path seperators with underscores
 
                 let sanitized_path = path
-                    .to_string_lossy()
+                    .to_string()
                     .chars()
                     .map(|c| if path::is_separator(c) { '_' } else { c })
                     .collect::<String>();


### PR DESCRIPTION
As we experienced in #212 there were several issues discovered with the mft library being used. It turns out a lot of the issues we have been experiencing have already been fixed by others. As a result I forked the library over to [here](https://github.com/reece394/mft) with cherry picked commits from https://github.com/omerbenamram/mft/pull/120, https://github.com/omerbenamram/mft/pull/119 and https://github.com/hodf-cye/mft/commit/e5c8b665ff13395df6e8706ab1ee07634f38ae03 as well as bumping up some of the rust dependencies. I haven't bumped them all yet due to some having significant changes that need testing. The intention for this is for either the cloning of the repo I have started or me transferring it over and then we can change it to the WithSecureLabs repos instead of being external. 

One issue that will need fixed is when dumping to JSON it outputs as one / instead of // and I believe JSON wants them escaped. CSV is fine however.

Managed to bump up the dependencies to latest which should help with maintainability going forward. I also fixed the benchmark file too that didn't account for changes in the code. 
When running tests on the library you should run:
cargo test -- --skip "readme_sect_library_usage_line_33" as skeptic isn't checking the readme properly (not a deal breaker)

Bitflags was the most troublesome due to them changing the way they serialised the output. I modified this code to use fmt:Display to restore the prior output however one output difference if you use the mft_dump binary the library outputs using the json output format the IndexRootFlags appear to output both SMALL_INDEX and LARGE_INDEX instead of previously just outputting LARGE_INDEX. I am not sure if this is a bug yet but it would be good to figure that one out. 