### PR TITLE
feat: support cloudtrail logs, and json.gz files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +289,7 @@ dependencies = [
  "clap",
  "crossterm",
  "evtx",
+ "flate2",
  "hex",
  "indicatif",
  "lazy_static",
@@ -690,6 +697,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "flate2"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,6 +1015,15 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "mio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ chrono-tz = { version = "0.10", features = ["serde"] }
 clap = { version = "4.0", features = ["derive"] }
 crossterm = "0.28"
 evtx = { version = "0.8", default-features = false }
+flate2 = "1.0"
 hex = "0.4.3"
 indicatif = "0.17"
 lazy_static = "1.4.0"

--- a/mappings/sigma-cloudtrail-logs-all.yml
+++ b/mappings/sigma-cloudtrail-logs-all.yml
@@ -1,0 +1,140 @@
+---
+name: Chainsaw's Sigma mappings for Cloudtrail
+kind: json
+rules: sigma
+
+groups:
+  - name: Sigma Detections (Cloudtrail Logs)
+    timestamp: eventTime
+    filter:
+      eventType:
+        - AwsApiCall
+        - AwsServiceEvent
+        - AwsConsoleAction
+        - AwsConsoleSignIn
+        - AwsVpceEvents
+    fields:
+      - from: eventName
+        to: eventName
+        visible: true
+      - from: requestParameters
+        to: requestParameters
+        visible: true
+      - from: userAgent
+        to: userAgent
+        visible: true
+      - from: userIdentity
+        to: userIdentity
+        visible: true
+
+      - from: eventID
+        to: eventID
+        visible: false
+      - from: recipientAccountId
+        to: recipientAccountId
+        visible: false
+      - from: accessKeyId
+        to: userIdentity.accessKeyId
+        visible: false
+      - from: accountId
+        to: userIdentity.accountId
+        visible: false
+      - from: arn
+        to: userIdentity.arn
+        visible: false
+      - from: attributes
+        to: userIdentity.sessionContext.attributes
+        visible: false
+      - from: byCreatedAfter
+        to: requestParameters.byCreatedAfter
+        visible: false
+      - from: byState
+        to: requestParameters.byState
+        visible: false
+      - from: byStatus
+        to: requestParameters.byStatus
+        visible: false
+      - from: cipherSuite
+        to: tlsDetails.cipherSuite
+        visible: false
+      - from: clientProvidedHostHeader
+        to: tlsDetails.clientProvidedHostHeader
+        visible: false
+      - from: creationDate
+        to: userIdentity.sessionContext.attributes.creationDate
+        visible: false
+      - from: errorCode
+        to: errorCode
+        visible: false
+      - from: errorMessage
+        to: errorMessage
+        visible: false
+      - from: eventCategory
+        to: eventCategory
+        visible: false
+      - from: eventSource
+        to: eventSource
+        visible: false
+      - from: eventTime
+        to: eventTime
+        visible: false
+      - from: eventType
+        to: eventType
+        visible: false
+      - from: eventVersion
+        to: eventVersion
+        visible: false
+      - from: lookupAttributes
+        to: requestParameters.lookupAttributes
+        visible: false
+      - from: managementEvent
+        to: managementEvent
+        visible: false
+      - from: maxResults
+        to: requestParameters.maxResults
+        visible: false
+      - from: mfaAuthenticated
+        to: userIdentity.sessionContext.attributes.mfaAuthenticated
+        visible: false
+      - from: name
+        to: requestParameters.name
+        visible: false
+      - from: principalId
+        to: userIdentity.principalId
+        visible: false
+      - from: readOnly
+        to: readOnly
+        visible: false
+      - from: requestID
+        to: requestID
+        visible: false
+      - from: responseElements
+        to: responseElements
+        visible: false
+      - from: sessionContext
+        to: userIdentity.sessionContext
+        visible: false
+      - from: sessionCredentialFromConsole
+        to: sessionCredentialFromConsole
+        visible: false
+      - from: sessionIssuer
+        to: userIdentity.sessionContext.sessionIssuer
+        visible: false
+      - from: sourceIPAddress
+        to: sourceIPAddress
+        visible: false
+      - from: tlsDetails
+        to: tlsDetails
+        visible: false
+      - from: tlsVersion
+        to: tlsDetails.tlsVersion
+        visible: false
+      - from: type
+        to: userIdentity.type
+        visible: false
+      - from: userName
+        to: userIdentity.userName
+        visible: false
+      - from: webIdFederationData
+        to: userIdentity.sessionContext.webIdFederationData
+        visible: false

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Utc};
 use self::esedb::{Esedb, Parser as EsedbParser};
 use self::evtx::{Evtx, Parser as EvtxParser};
 use self::hve::{Hve, Parser as HveParser};
-use self::json::{lines::Parser as JsonlParser, Json, Parser as JsonParser};
+use self::json::{Json, Parser as JsonParser, lines::Parser as JsonlParser};
 use self::mft::{Mft, Parser as MftParser};
 use self::xml::{Parser as XmlParser, Xml};
 
@@ -53,7 +53,7 @@ impl Kind {
         match self {
             Kind::Evtx => Some(vec!["evt".to_string(), "evtx".to_string()]),
             Kind::Hve => Some(vec!["hve".to_string()]),
-            Kind::Json => Some(vec!["json".to_string()]),
+            Kind::Json => Some(vec!["json".to_string(), "gz".to_string()]),
             Kind::Jsonl => Some(vec!["jsonl".to_string()]),
             Kind::Mft => Some(vec![
                 "mft".to_string(),
@@ -134,7 +134,7 @@ impl Reader {
                         parser: Parser::Evtx(parser),
                     })
                 }
-                "json" => {
+                "json" | "gz" => {
                     let parser = match JsonParser::load(file) {
                         Ok(parser) => parser,
                         Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,9 +16,9 @@ use chrono_tz::Tz;
 use clap::{ArgAction, Parser, Subcommand};
 
 use chainsaw::{
-    cli, get_files, lint as lint_rule, load as load_rule, set_writer, Document, Filter, Format,
-    Hunter, Reader, RuleKind, RuleLevel, RuleStatus, Searcher, ShimcacheAnalyser, SrumAnalyser,
-    Writer,
+    Document, Filter, Format, Hunter, Reader, RuleKind, RuleLevel, RuleStatus, Searcher,
+    ShimcacheAnalyser, SrumAnalyser, Writer, cli, get_files, lint as lint_rule, load as load_rule,
+    set_writer,
 };
 
 #[derive(Parser)]
@@ -337,7 +337,7 @@ fn print_title() {
 }
 
 fn resolve_col_width() -> Option<u32> {
-    use terminal_size::{terminal_size, Width};
+    use terminal_size::{Width, terminal_size};
     if let Some((Width(w), _)) = terminal_size() {
         match w {
             50..=120 => Some(20),
@@ -456,6 +456,7 @@ fn run() -> Result<()> {
             } else {
                 cs_eprintln!("[+] Loaded {} forensic artefacts ({})", files.len(), size);
             }
+            println!("Files: {:?}", files);
 
             let mut first = true;
             for path in &files {
@@ -466,7 +467,6 @@ fn run() -> Result<()> {
                     decode_data_streams,
                     data_streams_directory.clone(),
                 )?;
-
                 // We try to keep the reader and parser as generic as possible.
                 // However in some cases we need to pass artefact specific arguments to the parser.
                 // If the argument is not relevant for the artefact, it is ignored.
@@ -644,7 +644,10 @@ fn run() -> Result<()> {
                 }
             }
             if failed > 500 && sigma.is_empty() {
-                cs_eyellowln!("[!] {} rules failed to load, ensure Sigma rule paths are specified with the '-s' flag", failed);
+                cs_eyellowln!(
+                    "[!] {} rules failed to load, ensure Sigma rule paths are specified with the '-s' flag",
+                    failed
+                );
             }
             if count == 0 {
                 return Err(anyhow::anyhow!(
@@ -702,8 +705,8 @@ fn run() -> Result<()> {
                         .collect();
                     if scratch.is_empty() {
                         return Err(anyhow::anyhow!(
-                        "The specified file extension is not supported. Use --load-unknown to force loading",
-                    ));
+                            "The specified file extension is not supported. Use --load-unknown to force loading",
+                        ));
                     }
                 };
                 message = scratch
@@ -836,7 +839,9 @@ fn run() -> Result<()> {
                                         serde_yaml::to_string(&d)?
                                     }
                                     Filter::Expression(_) => {
-                                        cs_eyellowln!("[!] Tau does not support visual representation of expressions");
+                                        cs_eyellowln!(
+                                            "[!] Tau does not support visual representation of expressions"
+                                        );
                                         continue;
                                     }
                                 };
@@ -1111,7 +1116,10 @@ fn run() -> Result<()> {
                             } else {
                                 cs_eprintln!(
                                     "[+] Details about the tables related to the SRUM extensions:\n{}",
-                                    srum_db_info.table_details.to_string().trim_end_matches('\n')
+                                    srum_db_info
+                                        .table_details
+                                        .to_string()
+                                        .trim_end_matches('\n')
                                 );
 
                                 let json = srum_db_info.db_content;

--- a/src/rule/mod.rs
+++ b/src/rule/mod.rs
@@ -5,12 +5,11 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use tau_engine::{
-    core::{
-        optimiser,
-        parser::{Expression, Pattern},
-        Detection,
-    },
     Document,
+    core::{
+        Detection, optimiser,
+        parser::{Expression, Pattern},
+    },
 };
 
 use crate::file::Kind as FileKind;

--- a/src/rule/sigma.rs
+++ b/src/rule/sigma.rs
@@ -518,7 +518,6 @@ fn detections_to_tau(detection: Detection) -> Result<Mapping> {
         },
         None => bail!("missing condition"),
     };
-
     // Handle identifiers
     // NOTE: We can be inefficient here because the tree shaker will do the hard work for us!
     let mut patches = HashMap::new();


### PR DESCRIPTION

- Add support for Cloudtrail logs
    - Cloudtrail logs are in the format {"Records" : [...,...] } 
    - This doesn't play nicely with chainsaws rules so I suggest we do a quick check and flatten
- Add support for GZ compressed JSON files natively
    - This is the default export format for Cloudtrail 

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/04a4c42b-d5c6-4ce2-87b9-4f4a7f4823d4" />
