### PR TITLE
Support for PreAuthType field

### DIFF
--- a/mappings/sigma-event-logs-all.yml
+++ b/mappings/sigma-event-logs-all.yml
@@ -821,5 +821,5 @@ groups:
         to: Event.EventData.sha1
         visible: false
       - from: PreAuthType
-        to: Event.EventData.PreAuthType
+        to: int(Event.EventData.PreAuthType)
         visible: false

--- a/mappings/sigma-event-logs-all.yml
+++ b/mappings/sigma-event-logs-all.yml
@@ -820,3 +820,6 @@ groups:
       - from: sha1
         to: Event.EventData.sha1
         visible: false
+      - from: PreAuthType
+        to: Event.EventData.PreAuthType
+        visible: false


### PR DESCRIPTION
Mapping for sigma PreAuthType field, found in Keberos Authentication Service event ID 4768

Supports https://github.com/SigmaHQ/sigma/pull/5512

```
<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
  <System>
    <Provider Name="Microsoft-Windows-Security-Auditing" Guid="{54849625-5478-4994-a5ba-3e3b0328c30d}" /> 
    <EventID>4768</EventID> 
    <Version>0</Version> 
    <Level>0</Level> 
    <Task>14339</Task> 
    <Opcode>0</Opcode> 
    <Keywords>0x8020000000000000</Keywords> 
    <TimeCreated SystemTime="2024-05-28T06:32:40.2463627Z" /> 
    <EventRecordID>6231</EventRecordID> 
    <Correlation /> 
    <Execution ProcessID="752" ThreadID="3188" /> 
    <Channel>Security</Channel> 
    <Computer>DC01.acme.corp</Computer> 
    <Security /> 
  </System>
  <EventData>
    <Data Name="TargetUserName">john.smith</Data> 
    <Data Name="TargetDomainName">acme.corp</Data> 
    <Data Name="TargetSid">REDACTED</Data> 
    <Data Name="ServiceName">krbtgt</Data> 
    <Data Name="ServiceSid">REDACTED</Data> 
    <Data Name="TicketOptions">0x40800010</Data> 
    <Data Name="Status">0x0</Data> 
    <Data Name="TicketEncryptionType">0x17</Data> 
    <Data Name="PreAuthType">0</Data> 
    <Data Name="IpAddress">::ffff:10.0.0.1</Data> 
    <Data Name="IpPort">61965</Data> 
    <Data Name="CertIssuerName" /> 
    <Data Name="CertSerialNumber" /> 
    <Data Name="CertThumbprint" /> 
  </EventData>
</Event>
```